### PR TITLE
Change physics to bevy_rapier2d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,12 +110,6 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -539,14 +533,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_prototype_lyon"
-version = "0.5.0"
+name = "bevy_rapier2d"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a902a6ba040d8874fc8798443ccc2f920077ab8d2a869e301b5900bfdbcd66"
+checksum = "b54239dabc74ecc982a4dfcfa464326284303d6a85627d4a20e449263013fb9b"
 dependencies = [
  "bevy",
- "lyon_tessellation",
- "svgtypes",
+ "bitflags",
+ "log",
+ "nalgebra",
+ "rapier2d",
 ]
 
 [[package]]
@@ -1326,16 +1322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
-name = "duplicate"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2535fcf1437c9de0d91a3921351c474258abdb6440cd03bb5a7cf0547e7214"
-dependencies = [
- "heck",
- "proc-macro-error",
-]
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,21 +1387,6 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
-
-[[package]]
-name = "float-cmp"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75224bec9bfe1a65e2d34132933f2de7fe79900c96a0174307554244ece8150e"
-
-[[package]]
-name = "float_next_after"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "fnv"
@@ -1665,82 +1636,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "heron"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f23a4c500926d8dc9ec59cc6ae3c17f006bc4f7d2cc13f8d6ef993a8ba7867"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "heron_core",
- "heron_debug",
- "heron_macros",
- "heron_rapier",
-]
-
-[[package]]
-name = "heron_core"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5159c19d52d452251e2377294f3a34534fe9293eadc3bb2b4ba18fe3ff9d10d"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "duplicate",
- "smallvec",
-]
-
-[[package]]
-name = "heron_debug"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7d3db336b6c50ab7907fe58ffc239102a99aba1fc91a63657f4fe959bfcb79"
-dependencies = [
- "bevy",
- "bevy_prototype_lyon",
- "fnv",
- "heron_core",
- "heron_rapier",
- "lyon_path",
-]
-
-[[package]]
-name = "heron_macros"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146314054f01fc7c1a345dcc4dfedc7e3a792e845ce1c6d21c7c26f5383bd98b"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "heron_rapier"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdba166504110706edc3a1c614f4e6cba9ba001cd4569afc9afb44ea557b472d"
-dependencies = [
- "bevy",
- "cfg_aliases",
- "crossbeam",
- "fnv",
- "heron_core",
- "rapier2d",
 ]
 
 [[package]]
@@ -1971,6 +1872,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,7 +1893,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy-parallax",
- "heron",
+ "bevy_rapier2d",
 ]
 
 [[package]]
@@ -2006,36 +1913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "lyon_geom"
-version = "0.17.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce99ce77c22bfd8f39a95b9c749dffbfc3e2491ea30c874764c801a8b1485489"
-dependencies = [
- "arrayvec 0.5.2",
- "euclid",
- "num-traits",
-]
-
-[[package]]
-name = "lyon_path"
-version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0a59fdf767ca0d887aa61d1b48d4bbf6a124c1a45503593f7d38ab945bfbc0"
-dependencies = [
- "lyon_geom",
-]
-
-[[package]]
-name = "lyon_tessellation"
-version = "0.17.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7230e08dd0638048e46f387f255dbe7a7344a3e6705beab53242b5af25635760"
-dependencies = [
- "float_next_after",
- "lyon_path",
 ]
 
 [[package]]
@@ -2191,11 +2068,12 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
+checksum = "18a89248335f688e4bd994e6d030fd7e185eb41769b8c435395075425e100ac6"
 dependencies = [
  "approx",
+ "glam",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -2427,6 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm 0.2.2",
 ]
 
 [[package]]
@@ -2518,6 +2397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
+name = "optional"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2559,12 +2444,12 @@ dependencies = [
 
 [[package]]
 name = "parry2d"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e03714e76fd6708c1fa3fc4f58a66dabd723bb87865548657a037beaf9a8eea"
+checksum = "2841cebc29aaf7c69058b242742853d9b106c5245ed946090a75d941d23a6f5e"
 dependencies = [
  "approx",
- "arrayvec 0.7.2",
+ "arrayvec",
  "bitflags",
  "downcast-rs",
  "either",
@@ -2575,6 +2460,7 @@ dependencies = [
  "simba",
  "slab",
  "smallvec",
+ "spade",
 ]
 
 [[package]]
@@ -2655,30 +2541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,17 +2602,16 @@ checksum = "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6"
 
 [[package]]
 name = "rapier2d"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45d2910dbd279941b71ef9d20da877a0eada21f8117fcac70941e458100ea86"
+checksum = "43f7f18a9281f4c4176754437a768e1b7124ce5729060c8743db670f7ebb3c43"
 dependencies = [
  "approx",
- "arrayvec 0.7.2",
+ "arrayvec",
  "bit-vec",
  "bitflags",
  "crossbeam",
  "downcast-rs",
- "instant",
  "nalgebra",
  "num-derive",
  "num-traits",
@@ -2820,6 +2681,12 @@ name = "renderdoc-sys"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157"
+
+[[package]]
+name = "robust"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
 
 [[package]]
 name = "rodio"
@@ -2982,9 +2849,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "simba"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
+checksum = "13a2609e876d4f77f6ab7ff5254fc39b4f1927ba8e6db3d18be7c32534d3725e"
 dependencies = [
  "approx",
  "num-complex",
@@ -2992,12 +2859,6 @@ dependencies = [
  "paste",
  "wide",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "slab"
@@ -3021,6 +2882,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "spade"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333b8c21ebd9a45c5e955f3d7a1f0c4a2214847dd7e8e1abb69f34ec9b88882d"
+dependencies = [
+ "num-traits",
+ "optional",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]
@@ -3097,7 +2970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0dc6d20ce137f302edf90f9cd3d278866fd7fb139efca6f246161222ad6d87"
 dependencies = [
  "lazy_static",
- "libm",
+ "libm 0.1.4",
 ]
 
 [[package]]
@@ -3111,16 +2984,6 @@ name = "svg_fmt"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
-
-[[package]]
-name = "svgtypes"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c536faaff1a10837cfe373142583f6e27d81e96beba339147e77b67c9f260ff"
-dependencies = [
- "float-cmp",
- "siphasher",
-]
 
 [[package]]
 name = "syn"
@@ -3432,7 +3295,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec",
  "js-sys",
  "log",
  "naga",
@@ -3453,7 +3316,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec",
  "bitflags",
  "cfg_aliases",
  "codespan-reporting",
@@ -3476,7 +3339,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec",
  "ash",
  "bit-set",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ version = "0.1.0"
 [dependencies]
 bevy = "0.7.0"
 bevy-parallax = "0.1.2"
-heron = {version = "3.0.0", features = ["2d", "debug-2d"]}
+bevy_rapier2d = { version = "0.14.1", features = ["debug-render"] }

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -4,7 +4,7 @@ use bevy::{
     prelude::{App, Commands, Component, KeyCode, Plugin, Query, Res, Transform, With},
     transform::TransformBundle,
 };
-use heron::{CollisionLayers, CollisionShape, RigidBody};
+use bevy_rapier2d::prelude::*;
 
 use crate::{
     animation::Facing,
@@ -47,16 +47,15 @@ fn player_attack(
                 transform.translation.y,
                 ATTACK_LAYER,
             )))
-            .insert(RigidBody::Sensor)
-            .insert(CollisionShape::Cuboid {
-                half_extends: Vec3::new(ATTACK_WIDTH / 2., ATTACK_HEIGHT / 2., 0.),
-                border_radius: None,
-            })
-            .insert(facing.clone())
-            .insert(CollisionLayers::new(
-                BodyLayers::PlayerAttack,
-                BodyLayers::Enemy,
+            .insert(Collider::cuboid(ATTACK_WIDTH / 2., ATTACK_HEIGHT / 2.))
+            .insert(Sensor(true))
+            .insert(ActiveEvents::COLLISION_EVENTS)
+            .insert(ActiveCollisionTypes::default() | ActiveCollisionTypes::STATIC_STATIC)
+            .insert(CollisionGroups::new(
+                BodyLayers::PlayerAttack as u32,
+                BodyLayers::Enemy as u32,
             ))
+            .insert(facing.clone())
             .insert(MoveInDirection(dir * 300.)) //TODO: Put the velocity in a const
             // .insert(Velocity::from_linear(dir * 300.))
             .insert(Attack { damage: 10 });

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -1,6 +1,6 @@
 use bevy::{
     input::Input,
-    math::{Vec2, Vec3},
+    math::Vec2,
     prelude::{App, Commands, Component, KeyCode, Plugin, Query, Res, Transform, With},
     transform::TransformBundle,
 };

--- a/src/collisions.rs
+++ b/src/collisions.rs
@@ -4,16 +4,15 @@ use bevy::{
     math::Vec2,
     prelude::{Commands, EventReader, Query, Transform, With, Without},
 };
-use heron::{CollisionEvent, PhysicsLayer};
+use bevy_rapier2d::prelude::*;
 
 use crate::{attack::Attack, item::Item, movement::Knockback, state::State, Enemy, Player, Stats};
 
-#[derive(PhysicsLayer)]
 pub enum BodyLayers {
-    Enemy,
-    Player,
-    PlayerAttack,
-    Item,
+    Enemy = 0b0001,
+    Player = 0b0010,
+    PlayerAttack = 0b0100,
+    Item = 0b1000,
 }
 
 pub fn player_enemy_collision(
@@ -22,30 +21,66 @@ pub fn player_enemy_collision(
     mut enemy_query: Query<(&mut State, &mut Stats, &Transform), (With<Enemy>, Without<Player>)>,
     player_query: Query<(&State, &Stats, &Transform), (With<Player>, Without<Enemy>)>,
 ) {
-    events.iter().filter(|e| e.is_started()).for_each(|e| {
-        let (e1, e2) = e.rigid_body_entities();
-        let (l1, l2) = e.collision_layers();
+    for event in events.iter() {
+        if let CollisionEvent::Started(e1, e2, _flags) = event {
+            let (player, enemy);
+            if player_query.contains(*e1) && enemy_query.contains(*e2) {
+                (player, enemy) = (*e1, *e2);
+            } else {
+                (player, enemy) = (*e2, *e1);
+            }
 
-        let (player, enemy);
-        if l1.contains_group(BodyLayers::Player) && l2.contains_group(BodyLayers::Enemy) {
-            player = e1;
-            enemy = e2;
-        } else if l2.contains_group(BodyLayers::Player) && l1.contains_group(BodyLayers::Enemy) {
-            player = e2;
-            enemy = e1;
-        } else {
-            return;
+            if let Ok((mut e_state, mut e_stats, e_transform)) = enemy_query.get_mut(enemy) {
+                if let Ok((p_state, p_stats, p_transform)) = player_query.get(player) {
+                    if *p_state == State::Attacking {
+                        e_stats.health -= p_stats.damage;
+                        println! {"e_stats.health {:?}", e_stats.health};
+
+                        let force = 150.; //TODO: set this to a constant
+                        let mut direction = Vec2::new(0., 0.);
+
+                        if p_transform.translation.x < e_transform.translation.x {
+                            e_state.set(State::KnockedLeft);
+                            direction.x = force;
+                        } else {
+                            e_state.set(State::KnockedRight);
+                            direction.x = -force;
+                        }
+
+                        commands.entity(enemy).insert(Knockback {
+                            direction,
+                            duration: Timer::from_seconds(0.15, false),
+                        });
+                    }
+                }
+            }
         }
+    }
+}
 
-        if let Ok((mut e_state, mut e_stats, e_transform)) = enemy_query.get_mut(enemy) {
-            if let Ok((p_state, p_stats, p_transform)) = player_query.get(player) {
-                if *p_state == State::Attacking {
-                    e_stats.health -= p_stats.damage;
+pub fn player_attack_enemy_collision(
+    mut commands: Commands,
+    mut events: EventReader<CollisionEvent>,
+    mut enemy_query: Query<(&mut State, &mut Stats, &Transform), (With<Enemy>, Without<Player>)>,
+    attack_query: Query<(&Attack, &Transform)>,
+) {
+    for event in events.iter() {
+        if let CollisionEvent::Started(e1, e2, _flags) = event {
+            let (attack, enemy);
+            if attack_query.contains(*e1) && enemy_query.contains(*e2) {
+                (attack, enemy) = (*e1, *e2);
+            } else {
+                (attack, enemy) = (*e2, *e1);
+            }
+
+            if let Ok((mut e_state, mut e_stats, e_transform)) = enemy_query.get_mut(enemy) {
+                if let Ok((a_attack, a_transform)) = attack_query.get(attack) {
+                    e_stats.health -= a_attack.damage;
 
                     let force = 150.; //TODO: set this to a constant
                     let mut direction = Vec2::new(0., 0.);
 
-                    if p_transform.translation.x < e_transform.translation.x {
+                    if a_transform.translation.x < e_transform.translation.x {
                         e_state.set(State::KnockedLeft);
                         direction.x = force;
                     } else {
@@ -57,59 +92,12 @@ pub fn player_enemy_collision(
                         direction,
                         duration: Timer::from_seconds(0.15, false),
                     });
+
+                    commands.entity(attack).despawn_recursive();
                 }
             }
         }
-    });
-}
-
-pub fn player_attack_enemy_collision(
-    mut commands: Commands,
-    mut events: EventReader<CollisionEvent>,
-    mut enemy_query: Query<(&mut State, &mut Stats, &Transform), (With<Enemy>, Without<Player>)>,
-    attack_query: Query<(&Attack, &Transform)>,
-) {
-    events.iter().filter(|e| e.is_started()).for_each(|e| {
-        let (e1, e2) = e.rigid_body_entities();
-        let (l1, l2) = e.collision_layers();
-
-        let (attack, enemy);
-        if l1.contains_group(BodyLayers::PlayerAttack) && l2.contains_group(BodyLayers::Enemy) {
-            attack = e1;
-            enemy = e2;
-        } else if l2.contains_group(BodyLayers::PlayerAttack)
-            && l1.contains_group(BodyLayers::Enemy)
-        {
-            attack = e2;
-            enemy = e1;
-        } else {
-            return;
-        }
-
-        if let Ok((mut e_state, mut e_stats, e_transform)) = enemy_query.get_mut(enemy) {
-            if let Ok((a_attack, a_transform)) = attack_query.get(attack) {
-                e_stats.health -= a_attack.damage;
-
-                let force = 150.; //TODO: set this to a constant
-                let mut direction = Vec2::new(0., 0.);
-
-                if a_transform.translation.x < e_transform.translation.x {
-                    e_state.set(State::KnockedLeft);
-                    direction.x = force;
-                } else {
-                    e_state.set(State::KnockedRight);
-                    direction.x = -force;
-                }
-
-                commands.entity(enemy).insert(Knockback {
-                    direction,
-                    duration: Timer::from_seconds(0.15, false),
-                });
-
-                commands.entity(attack).despawn_recursive();
-            }
-        }
-    });
+    }
 }
 
 pub fn item_attacks_enemy_collision(
@@ -118,43 +106,37 @@ pub fn item_attacks_enemy_collision(
     mut enemy_query: Query<(&mut State, &mut Stats, &Transform), (With<Enemy>, Without<Item>)>,
     item_query: Query<(&Attack, &Transform), (With<Item>, Without<Enemy>)>,
 ) {
-    events.iter().filter(|e| e.is_started()).for_each(|e| {
-        let (e1, e2) = e.rigid_body_entities();
-        let (l1, l2) = e.collision_layers();
+    for event in events.iter() {
+        if let CollisionEvent::Started(e1, e2, _flags) = event {
+            let (item, enemy);
+            if item_query.contains(*e1) && enemy_query.contains(*e2) {
+                (item, enemy) = (*e1, *e2);
+            } else {
+                (item, enemy) = (*e2, *e1);
+            }
+            if let Ok((mut e_state, mut e_stats, e_transform)) = enemy_query.get_mut(enemy) {
+                if let Ok((a_attack, a_transform)) = item_query.get(item) {
+                    e_stats.health -= a_attack.damage;
 
-        let (item, enemy);
-        if l1.contains_group(BodyLayers::Item) && l2.contains_group(BodyLayers::Enemy) {
-            item = e1;
-            enemy = e2;
-        } else if l2.contains_group(BodyLayers::Item) && l1.contains_group(BodyLayers::Enemy) {
-            item = e2;
-            enemy = e1;
-        } else {
-            return;
-        }
+                    let force = 150.; //TODO: set this to a constant
+                    let mut direction = Vec2::new(0., 0.);
 
-        if let Ok((mut e_state, mut e_stats, e_transform)) = enemy_query.get_mut(enemy) {
-            if let Ok((a_attack, a_transform)) = item_query.get(item) {
-                e_stats.health -= a_attack.damage;
+                    if a_transform.translation.x < e_transform.translation.x {
+                        e_state.set(State::KnockedLeft);
+                        direction.x = force;
+                    } else {
+                        e_state.set(State::KnockedRight);
+                        direction.x = -force;
+                    }
 
-                let force = 150.; //TODO: set this to a constant
-                let mut direction = Vec2::new(0., 0.);
+                    commands.entity(enemy).insert(Knockback {
+                        direction,
+                        duration: Timer::from_seconds(0.15, false),
+                    });
 
-                if a_transform.translation.x < e_transform.translation.x {
-                    e_state.set(State::KnockedLeft);
-                    direction.x = force;
-                } else {
-                    e_state.set(State::KnockedRight);
-                    direction.x = -force;
-                }
-
-                commands.entity(enemy).insert(Knockback {
-                    direction,
-                    duration: Timer::from_seconds(0.15, false),
-                });
-
-                commands.entity(item).despawn_recursive();
+                    commands.entity(item).despawn_recursive();
+                };
             };
-        };
-    });
+        }
+    }
 }

--- a/src/collisions.rs
+++ b/src/collisions.rs
@@ -34,8 +34,6 @@ pub fn player_enemy_collision(
                 if let Ok((p_state, p_stats, p_transform)) = player_query.get(player) {
                     if *p_state == State::Attacking {
                         e_stats.health -= p_stats.damage;
-                        println! {"e_stats.health {:?}", e_stats.health};
-
                         let force = 150.; //TODO: set this to a constant
                         let mut direction = Vec2::new(0., 0.);
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,9 +1,9 @@
 use bevy::{
-    math::{Vec2, Vec3},
+    math::Vec2,
     prelude::{default, AssetServer, Commands, Component, EventReader, Res, Transform},
     sprite::SpriteBundle,
 };
-use heron::{CollisionLayers, CollisionShape, RigidBody};
+use bevy_rapier2d::prelude::*;
 
 use crate::{
     animation::Facing,
@@ -43,12 +43,14 @@ pub fn spawn_throwable_items(
             })
             .insert(Item)
             .insert(Pickable)
-            .insert(RigidBody::Sensor)
-            .insert(CollisionShape::Cuboid {
-                half_extends: Vec3::new(ITEM_WIDTH / 2., ITEM_HEIGHT / 2., 0.),
-                border_radius: None,
-            })
-            .insert(CollisionLayers::new(BodyLayers::Item, BodyLayers::Enemy))
+            .insert(Collider::cuboid(ITEM_WIDTH / 2., ITEM_HEIGHT / 2.))
+            .insert(Sensor(true))
+            .insert(ActiveEvents::COLLISION_EVENTS)
+            .insert(ActiveCollisionTypes::default() | ActiveCollisionTypes::STATIC_STATIC)
+            .insert(CollisionGroups::new(
+                BodyLayers::Item as u32,
+                BodyLayers::Enemy as u32,
+            ))
             .insert(Attack {
                 damage: consts::THROW_ITEM_DAMAGE,
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use bevy::{prelude::*, render::camera::ScalingMode, utils::HashMap};
 use bevy_parallax::{LayerData, ParallaxCameraComponent, ParallaxPlugin, ParallaxResource};
-use heron::{prelude::*, SensorShape};
+use bevy_rapier2d::prelude::*;
 
 mod animation;
 mod attack;
@@ -43,7 +43,8 @@ fn main() {
         })
         .add_event::<ThrowItemEvent>()
         .add_plugins(DefaultPlugins)
-        .add_plugin(PhysicsPlugin::default())
+        .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
+        .add_plugin(RapierDebugRenderPlugin::default())
         .add_plugin(AttackPlugin)
         .add_plugin(AnimationPlugin)
         .add_plugin(StatePlugin)
@@ -170,18 +171,14 @@ fn setup(
             movement_speed: 150.0,
         })
         .insert(Facing::Right)
-        .insert(RigidBody::Sensor)
-        .insert(Collisions::default())
-        .insert(CollisionShape::Cuboid {
-            half_extends: Vec3::new(
-                consts::PLAYER_SPRITE_WIDTH,
-                consts::PLAYER_HITBOX_HEIGHT,
-                0.,
-            ) / 8.,
-            border_radius: None,
-        })
-        .insert(CollisionLayers::all_masks::<BodyLayers>().with_group(BodyLayers::Player))
-        .insert(SensorShape)
+        .insert(Collider::cuboid(
+            consts::PLAYER_SPRITE_WIDTH / 8.,
+            consts::PLAYER_HITBOX_HEIGHT / 8.,
+        ))
+        .insert(Sensor(true))
+        .insert(ActiveEvents::COLLISION_EVENTS)
+        .insert(ActiveCollisionTypes::default() | ActiveCollisionTypes::STATIC_STATIC)
+        .insert(CollisionGroups::new(BodyLayers::Player as u32, 0b1111))
         .insert(Animation::new(7. / 60., animation_map.clone()))
         .insert(YSort(100.));
 
@@ -210,17 +207,14 @@ fn setup(
                 damage: 35,
                 movement_speed: 120.0,
             })
-            .insert(RigidBody::Sensor)
-            .insert(Collisions::default())
-            .insert(CollisionShape::Cuboid {
-                half_extends: Vec3::new(
-                    consts::PLAYER_SPRITE_WIDTH,
-                    consts::PLAYER_HITBOX_HEIGHT,
-                    0.,
-                ) / 8.,
-                border_radius: None,
-            })
-            .insert(CollisionLayers::all_masks::<BodyLayers>().with_group(BodyLayers::Enemy))
+            .insert(Collider::cuboid(
+                consts::PLAYER_SPRITE_WIDTH / 8.,
+                consts::PLAYER_HITBOX_HEIGHT / 8.,
+            ))
+            .insert(Sensor(true))
+            .insert(ActiveEvents::COLLISION_EVENTS)
+            .insert(ActiveCollisionTypes::default() | ActiveCollisionTypes::STATIC_STATIC)
+            .insert(CollisionGroups::new(BodyLayers::Enemy as u32, 0b1111))
             .insert(Animation::new(7. / 60., animation_map.clone()))
             .insert(YSort(100.));
     }


### PR DESCRIPTION
I've done a replacement of the heron physics crate and the physics code using it for bevy_rapier2d. I tried to stick closely to the original implementations when possible with the equivalent rapier API, with some small changes where necessary.

I believe functionality continues to be the same as it was.

This rewrite was motivated by changes in the bevy_rapier crate which make it more ergonomic and should lead to better support and keeping pace closely with rapier proper since the bevy_rapier is an official integration.