### PR TITLE
Add GitHub actions CI, with format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  check_formatting:
+    runs-on: ubuntu-latest
+    name: Check Rust formatting
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check


### PR DESCRIPTION
This blocks code that is not formatted (note: Actions may need to be activated on this repo).

Note that the other action that the README currently suggests:

```sh
cargo clippy -- -W clippy::correctness -D warnings
```

is not currently possible (without tweaks) because of some Bevy issues/characteristics, e.g. the following (known) problem:

    error: call to `std::mem::forget` with a value that does not implement `Drop`. Forgetting such a type is the same as dropping it
      --> src/main.rs:102:10
        |
    102 | #[derive(Bundle)]
        |          ^^^^^^
        |
    note: argument has type `Enemy`
      --> src/main.rs:102:10
        |
    102 | #[derive(Bundle)]
        |          ^^^^^^
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#forget_non_drop
        = note: this error originates in the derive macro `Bundle` (in Nightly builds, run with -Z macro-backtrace for more info)

Some of the suggestions are worth applying though, e.g. unnecessary `clone()` calls.