### PR TITLE
Camera Panning Fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,9 @@ fn setup(
     camera_bundle.orthographic_projection.scale = 16. * 14.;
     commands
         .spawn_bundle(camera_bundle)
+        .insert(Panning {
+            offset: Vec2::new(0., -consts::GROUND_Y),
+        })
         .insert(ParallaxCameraComponent);
 
     let texture_handle = asset_server.load("PlayerFishy(96x80).png");


### PR DESCRIPTION
Currently, when panning, the camera doesn't move from the camera, however the parallax background layers are moving, the further back the faster.

This PR fixes / improves the camera panning.
The Panning is now handled with a separate component storing the offset from the player. this way you can pan the camera independently from the player position. If you move the player, the camera keeps its offset.

Also, the parallax backgrounds moves correctly with the camera panning.

![unknown_2022 06 28-15 15](https://user-images.githubusercontent.com/24433899/176188522-28073437-389b-43e7-9631-641bd970bf83.gif)
