### PR TITLE
Hot reload

### DIFF
--- a/assets/beach/beach.level.yaml
+++ b/assets/beach/beach.level.yaml
@@ -1,3 +1,4 @@
+background_color: [101, 131, 162]
 parallax_background:
   layers:
     - speed: 0.98

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,7 @@ fn main() {
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
                 .with_system(hot_reload_level)
+                .with_system(hot_reload_fighters)
                 .into(),
         );
     }
@@ -394,6 +395,38 @@ fn load_fighters(
                     collision_groups: CollisionGroups::new(body_layers, BodyLayers::ALL),
                     ..default()
                 });
+        }
+    }
+}
+
+fn hot_reload_fighters(
+    mut fighters: Query<(
+        &Handle<Fighter>,
+        &mut Name,
+        &mut Handle<TextureAtlas>,
+        &mut Animation,
+        &mut Stats,
+    )>,
+    mut events: EventReader<AssetEvent<Fighter>>,
+    assets: Res<Assets<Fighter>>,
+) {
+    for event in events.iter() {
+        if let AssetEvent::Modified { handle } = event {
+            for (fighter_handle, mut name, mut atlas_handle, mut animation, mut stats) in
+                fighters.iter_mut()
+            {
+                if fighter_handle == handle {
+                    let fighter = assets.get(fighter_handle).unwrap();
+
+                    *name = Name::new(fighter.meta.name.clone());
+                    *atlas_handle = fighter.atlas_handle.clone();
+                    *animation = Animation::new(
+                        fighter.meta.spritesheet.animation_fps,
+                        fighter.meta.spritesheet.animations.clone(),
+                    );
+                    *stats = fighter.meta.stats.clone();
+                }
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn main() {
 
     app.insert_resource(engine_config.clone())
         .insert_resource(asset_server_settings)
-        .insert_resource(ClearColor(Color::rgb(0.494, 0.658, 0.650)))
+        .insert_resource(ClearColor(Color::BLACK))
         .insert_resource(WindowDescriptor {
             title: "Fish Fight Punchy".to_string(),
             scale_factor_override: Some(1.0),
@@ -288,6 +288,9 @@ fn load_level(
         parallax.window_size = Vec2::new(window.width(), window.height());
         parallax.create_layers(&mut commands, &asset_server, &mut texture_atlases);
 
+        // Set the clear color
+        commands.insert_resource(ClearColor(level.meta.background_color()));
+
         // Spawn the player
         let ground_offset = Vec3::new(0.0, consts::GROUND_Y, 0.0);
         let player_pos = level.meta.player_spawn.location + ground_offset;
@@ -341,6 +344,8 @@ fn hot_reload_level(
                 *parallax = level.meta.parallax_background.get_resource();
                 parallax.window_size = Vec2::new(window.width(), window.height());
                 parallax.create_layers(&mut commands, &asset_server, &mut texture_atlases);
+
+                commands.insert_resource(ClearColor(level.meta.background_color()));
             }
         }
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,6 @@
 use bevy::{
     math::{UVec2, Vec2, Vec3},
-    prelude::{Component, Handle},
+    prelude::{Color, Component, Handle},
     reflect::TypeUuid,
     sprite::TextureAtlas,
     utils::HashMap,
@@ -34,10 +34,21 @@ pub struct Level {
 #[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct LevelMeta {
+    pub background_color: [u8; 3],
     pub parallax_background: ParallaxMeta,
     pub player_spawn: FighterSpawnMeta,
     #[serde(default)]
     pub enemies: Vec<FighterSpawnMeta>,
+}
+
+impl LevelMeta {
+    pub fn background_color(&self) -> Color {
+        Color::rgb_u8(
+            self.background_color[0],
+            self.background_color[1],
+            self.background_color[2],
+        )
+    }
 }
 
 #[derive(TypeUuid, Clone, Debug)]


### PR DESCRIPTION
Hot reload fighters and levels!

There is one other way we could have implemented this which has it's own trad-offs.

It's currently implemented by having a system watch for asset updated events. There is one such system for each kind of asset, in this case `Level`s and `Fighter`s. There is a little bit of duplication of the level/fighter spawn logic in the hot reload systems, because we are updating some of the same components, but not all of the components.

The alternative strategy for fighers ( though not for levels because it involves inserting resources ) would be to insert `Handle<Stats>` components onto the fighter entities instead of `Stats` components, for instance.

While this removes the need for a dedicated hot reload system and any duplication in the update logic, it also means that we can't just access the `Stats` component on a player without also adding `Res<Assets<Stats>>` to the system and making sure to do a `assets.get(stats_handle)`. So the systems accessing player stats becomes more a little more verbose.

I'm not sure what's going to be better in the long run, and we don't have to use one strategy for everything, we can take it on a case-by-case basis.

I feel like right now, because the hot reload systems are simple and small, it's probably not a big deal to have the small amount of duplication, but I could go either way with it if you want to use handles instead.