### PR TITLE
Debug Features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy-inspector-egui"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a758d0cf2b972292038bebef85005986c94a6545e36d73495937eb53216186f0"
+dependencies = [
+ "bevy",
+ "bevy-inspector-egui-derive",
+ "bevy_egui",
+ "image",
+ "pretty-type-name",
+]
+
+[[package]]
+name = "bevy-inspector-egui-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34652d3e6733bcb48375c05b0ad0a71f0222045cf73011a9e6bb003546bf629b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bevy-parallax"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +588,18 @@ checksum = "20288df0f70ff258bbaffaf55209f1271a7436438591bbffc3d81e4d84b423f2"
 dependencies = [
  "bevy_reflect",
  "glam",
+]
+
+[[package]]
+name = "bevy_mod_debugdump"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b972ed434c5c2231b2a19f6935671b72b40451abd73548e3e9dd44871164205d"
+dependencies = [
+ "bevy_app",
+ "bevy_ecs",
+ "bevy_render",
+ "pretty-type-name",
 ]
 
 [[package]]
@@ -2090,8 +2126,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bevy",
+ "bevy-inspector-egui",
  "bevy-parallax",
  "bevy_egui",
+ "bevy_mod_debugdump",
  "bevy_rapier2d",
  "iyes_loopless",
  "serde",
@@ -2809,6 +2847,12 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "pretty-type-name"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8815d101cfb4cb491154896bdab292a395a7ac9ab185a9941a2f5be0135900d"
 
 [[package]]
 name = "proc-macro-crate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ dependencies = [
  "bevy-inspector-egui-derive",
  "bevy_egui",
  "image",
+ "nalgebra",
  "pretty-type-name",
 ]
 
@@ -257,6 +258,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "bevy-inspector-egui-rapier"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28252b5958ec6d31b7308cc1a70c0b3999fbe6f7a66dece2afc17c0dfcb0e69a"
+dependencies = [
+ "bevy",
+ "bevy-inspector-egui",
+ "bevy_rapier2d",
 ]
 
 [[package]]
@@ -2127,6 +2139,7 @@ dependencies = [
  "anyhow",
  "bevy",
  "bevy-inspector-egui",
+ "bevy-inspector-egui-rapier",
  "bevy-parallax",
  "bevy_egui",
  "bevy_mod_debugdump",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ bevy-inspector-egui = { version = "0.11", optional = true }
 
 [features]
 default = []
-debug = ["bevy-inspector-egui", "bevy_mod_debugdump"]
+debug = ["bevy-inspector-egui"]
+schedule_graph = ["bevy_mod_debugdump"]
 
 # Enable optimizations for dependencies but not for our code
 [profile.dev.package."*"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,13 @@ serde_yaml = "0.8.24"
 thiserror = "1.0.31"
 structopt = "0.3.26"
 
+bevy_mod_debugdump = { version = "0.4", optional = true }
+bevy-inspector-egui = { version = "0.11", optional = true }
+
+[features]
+default = []
+debug = ["bevy-inspector-egui", "bevy_mod_debugdump"]
+
 # Enable optimizations for dependencies but not for our code
 [profile.dev.package."*"]
 opt-level = 3
@@ -29,4 +36,3 @@ lto = true
 codegen-units = 1 # Improves physics performance for release builds
 
 #TODO turn this into a debug feature
-# bevy_mod_debugdump = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ structopt = "0.3.26"
 
 bevy_mod_debugdump = { version = "0.4", optional = true }
 bevy-inspector-egui = { version = "0.11", optional = true }
-
+bevy-inspector-egui-rapier = { version = "0.4", optional = true, features = ["rapier2d"] }
 [features]
 default = []
-debug = ["bevy-inspector-egui"]
+debug = ["bevy-inspector-egui", "bevy-inspector-egui-rapier"]
 schedule_graph = ["bevy_mod_debugdump"]
 
 # Enable optimizations for dependencies but not for our code

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -25,6 +25,7 @@ impl Plugin for AnimationPlugin {
     }
 }
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component, PartialEq, Eq, Clone)]
 pub enum Facing {
     Left,

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -22,6 +22,7 @@ impl Plugin for AttackPlugin {
     }
 }
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component)]
 pub struct Attack {
     pub damage: i32,

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -13,6 +13,7 @@ use bevy_parallax::ParallaxMoveEvent;
 
 use crate::{consts, Player};
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component)]
 pub struct Panning {
     pub offset: Vec2,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use bevy_rapier2d::prelude::*;
 use iyes_loopless::prelude::*;
 use structopt::StructOpt;
 
+#[cfg(feature = "debug")]
+use bevy_inspector_egui::WorldInspectorPlugin;
+
 mod animation;
 mod assets;
 mod attack;
@@ -165,7 +168,7 @@ fn main() {
         .add_event::<ThrowItemEvent>()
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
-        .add_plugin(RapierDebugRenderPlugin::default())
+        // .add_plugin(RapierDebugRenderPlugin::default())
         .add_plugin(AttackPlugin)
         .add_plugin(AnimationPlugin)
         .add_plugin(StatePlugin)
@@ -203,6 +206,10 @@ fn main() {
             camera_follow_player.run_in_state(GameState::InGame),
         )
         .add_system_to_stage(CoreStage::Last, despawn_entities);
+
+    #[cfg(feature = "debug")]
+    app.add_plugin(RapierDebugRenderPlugin::default())
+        .add_plugin(WorldInspectorPlugin::new());
 
     assets::register(&mut app);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,9 @@ use iyes_loopless::prelude::*;
 use structopt::StructOpt;
 
 #[cfg(feature = "debug")]
-use bevy_inspector_egui::WorldInspectorPlugin;
+use bevy_inspector_egui::{Inspectable, RegisterInspectable, WorldInspectorPlugin};
+#[cfg(feature = "debug")]
+use bevy_inspector_egui_rapier::InspectableRapierPlugin;
 
 #[cfg(feature = "schedule_graph")]
 use bevy::log::LogPlugin;
@@ -30,7 +32,7 @@ mod ui;
 mod y_sort;
 
 use animation::*;
-use attack::AttackPlugin;
+use attack::{Attack, AttackPlugin};
 use camera::*;
 use collisions::*;
 use item::{spawn_throwable_items, ThrowItemEvent};
@@ -49,6 +51,7 @@ pub struct Player;
 #[derive(Component)]
 pub struct Enemy;
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Stats {
@@ -216,7 +219,17 @@ fn main() {
 
     #[cfg(feature = "debug")]
     app.add_plugin(RapierDebugRenderPlugin::default())
-        .add_plugin(WorldInspectorPlugin::new());
+        .add_plugin(InspectableRapierPlugin)
+        .add_plugin(WorldInspectorPlugin::new())
+        .register_inspectable::<Stats>()
+        .register_inspectable::<State>()
+        .register_inspectable::<MoveInDirection>()
+        .register_inspectable::<MoveInArc>()
+        .register_inspectable::<Rotate>()
+        .register_inspectable::<Attack>()
+        .register_inspectable::<YSort>()
+        .register_inspectable::<Facing>()
+        .register_inspectable::<Panning>();
 
     assets::register(&mut app);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ use structopt::StructOpt;
 #[cfg(feature = "debug")]
 use bevy_inspector_egui::WorldInspectorPlugin;
 
+#[cfg(feature = "schedule_graph")]
+use bevy::log::LogPlugin;
+
 mod animation;
 mod assets;
 mod attack;
@@ -157,6 +160,12 @@ fn main() {
         asset_server_settings.asset_folder = asset_dir.clone();
     }
 
+    #[cfg(feature = "schedule_graph")]
+    app.add_plugins_with(DefaultPlugins, |plugins| {
+        plugins.disable::<bevy::log::LogPlugin>()
+    });
+    #[cfg(not(feature = "schedule_graph"))]
+    app.add_plugins(DefaultPlugins);
     app.insert_resource(engine_config.clone())
         .insert_resource(asset_server_settings)
         .insert_resource(ClearColor(Color::rgb(0.494, 0.658, 0.650)))
@@ -166,9 +175,7 @@ fn main() {
             ..Default::default()
         })
         .add_event::<ThrowItemEvent>()
-        .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
-        // .add_plugin(RapierDebugRenderPlugin::default())
         .add_plugin(AttackPlugin)
         .add_plugin(AnimationPlugin)
         .add_plugin(StatePlugin)
@@ -220,6 +227,9 @@ fn main() {
     let game_asset = engine_config.game_asset;
     let handle: Handle<Game> = asset_server.load(&game_asset);
     app.world.insert_resource(handle);
+
+    #[cfg(feature = "schedule_graph")]
+    bevy_mod_debugdump::print_schedule(&mut app);
 
     app.run();
 }

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -12,6 +12,7 @@ use crate::{
     animation::Facing, consts, item::ThrowItemEvent, state::State, DespawnMarker, Player, Stats,
 };
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component, Deref, DerefMut)]
 pub struct MoveInDirection(pub Vec2);
 
@@ -136,6 +137,7 @@ pub fn move_direction_system(
     }
 }
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component)]
 pub struct MoveInArc {
     pub radius: Vec2,
@@ -182,6 +184,7 @@ pub fn move_in_arc_system(
     }
 }
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component)]
 pub struct Rotate {
     pub speed: f32,

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,7 @@ impl Plugin for StatePlugin {
     }
 }
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component, Debug, PartialEq, Eq, Hash, Clone, Copy, Deserialize)]
 #[serde(try_from = "String")]
 pub enum State {

--- a/src/y_sort.rs
+++ b/src/y_sort.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::{Component, Query, Transform};
 
+#[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component, Default)]
 pub struct YSort(f32);
 


### PR DESCRIPTION
Set up bevy-inspector-egui along with its rapier integration crate behind debug feature. Registers some components inspectable. Also moved rapier debug rendering to be behind debug feature. We may want to change this back or we might consider making debug utilities accessible behind a menu or keybind instead of feature flag.

Sets up bevy_mod_debugdump behind shedule_graph feature.
Used by calling `cargo run --features schedule_graph | dot -Tsvg -o output.svg` to render a svg of the system schedule graph.

Closes https://github.com/fishfight/punchy/issues/21