### PR TITLE
Fix Camera Z Position Changing

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -191,7 +191,10 @@ fn pause_menu(
                                 commands.entity(entity).despawn();
                             }
                             // Reset camera position
-                            *camera_transform.single_mut() = Transform::default();
+                            let mut camera_transform = camera_transform.single_mut();
+                            camera_transform.translation.x = 0.0;
+                            camera_transform.translation.y = 0.0;
+
                             // Show the main menu
                             commands.insert_resource(NextState(GameState::MainMenu));
                         }


### PR DESCRIPTION
Forgot to not change the camera Z position when resetting the camera
location after going back to home menu.

Fixes an issue where the camera couldn't see anything but the background
after starting the game, going back to the main menu, and starting the
game again.