### PR TITLE
Move move_in_arc and rotate systems to PostUpdate stage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,10 +234,8 @@ fn main() {
                 .with_system(kill_entities)
                 .with_system(knockback_system)
                 .with_system(move_direction_system)
-                .with_system(move_in_arc_system)
                 .with_system(throw_item_system)
                 .with_system(item_attacks_enemy_collision)
-                .with_system(rotate_system)
                 .with_system(set_target_near_player)
                 .with_system(move_to_target)
                 .with_system(pause)
@@ -248,6 +246,8 @@ fn main() {
             CoreStage::PostUpdate,
             ConditionSet::new()
                 .run_in_state(GameState::InGame)
+                .with_system(move_in_arc_system)
+                .with_system(rotate_system)
                 .with_system(camera_follow_player)
                 .into(),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,9 +244,12 @@ fn main() {
                 .into(),
         )
         .add_system(unpause.run_in_state(GameState::Paused))
-        .add_system_to_stage(
+        .add_system_set_to_stage(
             CoreStage::PostUpdate,
-            camera_follow_player.run_in_state(GameState::InGame),
+            ConditionSet::new()
+                .run_in_state(GameState::InGame)
+                .with_system(camera_follow_player)
+                .into(),
         )
         .add_system_to_stage(CoreStage::Last, despawn_entities);
 


### PR DESCRIPTION
This is required, in order to avoid 1-frame lag. With the previous design, they would not be able to find items spawned in the same frame.

Closes #37, however, it'd be much better to fully redesign the systems flow in order to take into account 1-frame-lag issues. Moving lag-sensitive systems into PostUpdate makes sense, but it's cleaner design to create one (or more) adhoc stages, in order to structure the flow clearly.