### PR TITLE
Use Engine Config For Menu Skip Functionality

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,4 +14,8 @@ pub struct EngineConfig {
     /// The .game.yaml asset to load at startup
     #[structopt(default_value = "default.game.yaml")]
     pub game_asset: String,
+
+    /// Skip the menu and automatically start the game
+    #[structopt(short = "s", long)]
+    pub auto_start: bool,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,6 +9,7 @@ use leafwing_input_manager::prelude::ActionState;
 
 use crate::{
     assets::EguiFont,
+    config::EngineConfig,
     input::MenuAction,
     metadata::{localization::LocalizationExt, ButtonStyle, FontStyle, GameMeta},
     GameState,
@@ -18,8 +19,6 @@ use self::widgets::{bordered_button::BorderedButton, bordered_frame::BorderedFra
 
 pub mod hud;
 pub mod widgets;
-
-const SKIP_MENU_ENV_VAR: &str = "PUNCHY_SKIP_MENU";
 
 pub struct UIPlugin;
 
@@ -296,6 +295,7 @@ fn main_menu(
     mut egui_context: ResMut<EguiContext>,
     game: Res<GameMeta>,
     localization: Res<Localization>,
+    engine_config: Res<EngineConfig>,
 ) {
     let ui_theme = &game.ui_theme;
 
@@ -343,10 +343,7 @@ fn main_menu(
                                 start_button.request_focus();
                             }
 
-                            let skip_menu_val =
-                                std::env::var(SKIP_MENU_ENV_VAR).unwrap_or(String::from(""));
-
-                            if start_button.clicked() || !skip_menu_val.is_empty() {
+                            if start_button.clicked() || engine_config.auto_start {
                                 commands.insert_resource(game.start_level_handle.clone());
                                 commands.insert_resource(NextState(GameState::LoadingLevel));
                             }


### PR DESCRIPTION
I thought that an engine config parameter made sense as a spot for the new auto-start functionality added by @64kramsystem ( great idea BTW! ).

After I get #34 finished, which is my next task, this will also make it work in the web builds which could be useful.