### PR TITLE
Fix Missing Label Warnings

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,7 @@
 use bevy::{prelude::*, utils::HashMap, window::WindowId};
 use bevy_egui::{
     egui::{self, style::Margin},
-    EguiContext, EguiInput, EguiPlugin, EguiSettings, EguiSystem,
+    EguiContext, EguiInput, EguiPlugin, EguiSettings,
 };
 use bevy_fluent::Localization;
 use iyes_loopless::prelude::*;
@@ -25,12 +25,7 @@ pub struct UIPlugin;
 impl Plugin for UIPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugin(EguiPlugin)
-            .add_system(
-                handle_menu_input
-                    .run_if_resource_exists::<GameMeta>()
-                    .after(EguiSystem::ProcessInput)
-                    .before(EguiSystem::BeginFrame),
-            )
+            .add_system(handle_menu_input.run_if_resource_exists::<GameMeta>())
             .add_enter_system(GameState::MainMenu, spawn_main_menu_background)
             .add_exit_system(GameState::MainMenu, despawn_main_menu_background)
             .add_system(hud::render_hud.run_in_state(GameState::InGame))


### PR DESCRIPTION
Fixes #67

According to the egui docs it seems like those labels should have existed, but debug dump of the schedule graph seems to indicate otherwise.

It seems to work just fine without the `.before()` and `.after()` flags so I think we'll just remove them and figure out what we need to do if we see issues later.