### PR TITLE
Refactor fighters spawning

### DIFF
--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -1,6 +1,10 @@
 use bevy::prelude::*;
 
-use crate::animation::Facing;
+use crate::{
+    animation::Facing,
+    consts,
+    metadata::{FighterMeta, FighterSpawnMeta},
+};
 
 #[derive(Component)]
 pub struct Enemy;
@@ -9,13 +13,26 @@ pub struct Enemy;
 pub struct EnemyBundle {
     enemy: Enemy,
     facing: Facing,
+    #[bundle]
+    transform_bundle: TransformBundle,
+    fighter_handle: Handle<FighterMeta>,
 }
 
-impl Default for EnemyBundle {
-    fn default() -> Self {
+impl EnemyBundle {
+    pub fn new(enemy_meta: &FighterSpawnMeta) -> Self {
+        let ground_offset = Vec3::new(0.0, consts::GROUND_Y, 0.0);
+        let enemy_pos = enemy_meta.location + ground_offset;
+
+        let transform_bundle =
+            TransformBundle::from_transform(Transform::from_translation(enemy_pos));
+
+        let fighter_handle = enemy_meta.fighter_handle.clone();
+
         EnemyBundle {
             enemy: Enemy,
             facing: Facing::Left,
+            transform_bundle,
+            fighter_handle,
         }
     }
 }

--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -1,0 +1,21 @@
+use bevy::prelude::*;
+
+use crate::animation::Facing;
+
+#[derive(Component)]
+pub struct Enemy;
+
+#[derive(Bundle)]
+pub struct EnemyBundle {
+    enemy: Enemy,
+    facing: Facing,
+}
+
+impl Default for EnemyBundle {
+    fn default() -> Self {
+        EnemyBundle {
+            enemy: Enemy,
+            facing: Facing::Left,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,11 @@ use bevy::{
 };
 use bevy_parallax::{ParallaxPlugin, ParallaxResource};
 use bevy_rapier2d::prelude::*;
+use enemy::*;
 use input::MenuAction;
 use iyes_loopless::prelude::*;
 use leafwing_input_manager::prelude::*;
+use player::*;
 use rand::{seq::SliceRandom, Rng};
 use structopt::StructOpt;
 
@@ -30,6 +32,7 @@ mod camera;
 mod collisions;
 mod config;
 mod consts;
+mod enemy;
 mod game_init;
 mod input;
 mod item;
@@ -37,6 +40,7 @@ mod localization;
 mod metadata;
 mod movement;
 mod platform;
+mod player;
 mod state;
 mod ui;
 mod y_sort;
@@ -58,12 +62,6 @@ use crate::{
     config::EngineConfig,
     input::{CameraAction, PlayerAction},
 };
-
-#[derive(Component)]
-pub struct Player;
-
-#[derive(Component)]
-pub struct Enemy;
 
 #[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component, Deserialize, Clone, Debug)]
@@ -137,34 +135,6 @@ impl Default for PhysicsBundle {
             active_collision_types: ActiveCollisionTypes::default()
                 | ActiveCollisionTypes::STATIC_STATIC,
             collision_groups: CollisionGroups::default(),
-        }
-    }
-}
-
-#[derive(Bundle)]
-struct PlayerBundle {
-    player: Player,
-    facing: Facing,
-}
-impl Default for PlayerBundle {
-    fn default() -> Self {
-        PlayerBundle {
-            player: Player,
-            facing: Facing::Right,
-        }
-    }
-}
-
-#[derive(Bundle)]
-struct EnemyBundle {
-    enemy: Enemy,
-    facing: Facing,
-}
-impl Default for EnemyBundle {
-    fn default() -> Self {
-        EnemyBundle {
-            enemy: Enemy,
-            facing: Facing::Left,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,14 +332,7 @@ fn load_level(
 
         // Spawn the enemies
         for enemy in &level.enemies {
-            let ground_offset = Vec3::new(0.0, consts::GROUND_Y, 0.0);
-            let enemy_pos = enemy.location + ground_offset;
-            commands
-                .spawn_bundle(TransformBundle::from_transform(
-                    Transform::from_translation(enemy_pos),
-                ))
-                .insert(enemy.fighter_handle.clone())
-                .insert_bundle(EnemyBundle::default());
+            commands.spawn_bundle(EnemyBundle::new(&enemy));
         }
 
         commands.insert_resource(level.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,27 +326,13 @@ fn load_level(
         commands.insert_resource(ClearColor(level.background_color()));
 
         // Spawn the players
-        let ground_offset = Vec3::new(0.0, consts::GROUND_Y, 0.0);
         for (i, player) in level.players.iter().enumerate() {
-            let player_pos = player.location + ground_offset;
-            commands
-                .spawn_bundle(TransformBundle::from_transform(
-                    Transform::from_translation(player_pos),
-                ))
-                .insert(player.fighter_handle.clone())
-                .insert_bundle(PlayerBundle::default())
-                .insert_bundle(InputManagerBundle {
-                    input_map: game
-                        .default_input_maps
-                        .get_player_map(i)
-                        .map(|mut map| map.set_gamepad(Gamepad(i)).build())
-                        .unwrap_or_default(),
-                    ..default()
-                });
+            commands.spawn_bundle(PlayerBundle::new(&player, i, &*game));
         }
 
         // Spawn the enemies
         for enemy in &level.enemies {
+            let ground_offset = Vec3::new(0.0, consts::GROUND_Y, 0.0);
             let enemy_pos = enemy.location + ground_offset;
             commands
                 .spawn_bundle(TransformBundle::from_transform(

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,0 +1,21 @@
+use bevy::prelude::*;
+
+use crate::animation::Facing;
+
+#[derive(Component)]
+pub struct Player;
+
+#[derive(Bundle)]
+pub struct PlayerBundle {
+    player: Player,
+    facing: Facing,
+}
+
+impl Default for PlayerBundle {
+    fn default() -> Self {
+        PlayerBundle {
+            player: Player,
+            facing: Facing::Right,
+        }
+    }
+}

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,6 +1,12 @@
 use bevy::prelude::*;
+use leafwing_input_manager::InputManagerBundle;
 
-use crate::animation::Facing;
+use crate::{
+    animation::Facing,
+    consts,
+    input::PlayerAction,
+    metadata::{FighterMeta, FighterSpawnMeta, GameMeta},
+};
 
 #[derive(Component)]
 pub struct Player;
@@ -9,13 +15,38 @@ pub struct Player;
 pub struct PlayerBundle {
     player: Player,
     facing: Facing,
+    #[bundle]
+    transform_bundle: TransformBundle,
+    fighter_handle: Handle<FighterMeta>,
+    #[bundle]
+    input_manager_bundle: InputManagerBundle<PlayerAction>,
 }
 
-impl Default for PlayerBundle {
-    fn default() -> Self {
+impl PlayerBundle {
+    pub fn new(player_meta: &FighterSpawnMeta, player_i: usize, game_meta: &GameMeta) -> Self {
+        let ground_offset = Vec3::new(0.0, consts::GROUND_Y, 0.0);
+        let player_pos = player_meta.location + ground_offset;
+
+        let transform_bundle =
+            TransformBundle::from_transform(Transform::from_translation(player_pos));
+
+        let fighter_handle = player_meta.fighter_handle.clone();
+
+        let input_manager_bundle = InputManagerBundle {
+            input_map: game_meta
+                .default_input_maps
+                .get_player_map(player_i)
+                .map(|mut map| map.set_gamepad(Gamepad(player_i)).build())
+                .unwrap_or_default(),
+            ..default()
+        };
+
         PlayerBundle {
             player: Player,
             facing: Facing::Right,
+            transform_bundle,
+            fighter_handle,
+            input_manager_bundle,
         }
     }
 }


### PR DESCRIPTION
Extract spawning types and logic from main into player.rs and enemy.rs, and extended the respective bundles to make all the components explicit.

Right now, main.rs still has a mix of different things (e.g. player belly flop attack), so other things should be moved out.

There are still some