### PR TITLE
Add Clippy correctness checks to CI (WIP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,14 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+  clippy_correctness_checks:
+    runs-on: ubuntu-latest
+    name: Clippy correctness checks
+    steps:
+      - name: Install Alsa dev library
+        run: sudo apt install libasound2-dev libudev-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -W clippy::correctness -D warnings


### PR DESCRIPTION
NOTE: currently testing caching on a separate repo; this PR works, but has no caching.

Hm. It takes, as of now, approximately 6 minutes to compile (and check, which takes a negligible time).

This can likely be made very fast by caching the target and cargo dir on master pushes.