### PR TITLE
CI: Add Clippy correctness checks (and Cargo check data caching)

### DIFF
--- a/.github/workflows/build-caches.yml
+++ b/.github/workflows/build-caches.yml
@@ -1,0 +1,28 @@
+name: Build caches
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  # Watch out! Clippy (cache) data is shared with build data, but it's not the same.
+  # In order to cache build, add a separate job (or extend this).
+  build_clippy_cache:
+    name: Build Clippy cache
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dev packages
+      run: sudo apt install libasound2-dev libudev-dev
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - uses: actions-rs/cargo@v1
+      with:
+        command: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,23 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+  clippy_correctness_checks:
+    runs-on: ubuntu-latest
+    name: Clippy correctness checks
+    steps:
+      - name: Install Alsa dev library
+        run: sudo apt install libasound2-dev libudev-dev
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -W clippy::correctness -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check Rust formatting
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/cargo@v1
         with:
           command: fmt


### PR DESCRIPTION
Add Clippy correctness checks. In order to make CI run in reasonable time (tens of seconds), a cache workflow has been added, which runs on each master push.

Some notes:

- the master workflow is required, because Github Actions cache is _not_ shared between PRs, but only (within a single PR, or between master and the PRs)
- the other reason to add the master caching workflow is that it can be trivially extended to cache also the build, in case we'll add testing or similar, in the future

This CI will build slowly; after merging, subsequent PRs will run fast.

For example runs/timings, see:

- master workflow run: https://github.com/64kramsystem/punchy-dev/actions/runs/2664626729
- PR workflow run: https://github.com/64kramsystem/punchy-dev/actions/runs/2664677214