### PR TITLE
Disable LTO entirely for dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ debug = false
 
 [profile.dev]
 opt-level = 1
+lto = "off"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Even thin LTO (dev default) takes around 30/40% of the compilation time. Since there is not performance pressure right now (in dev), it can be entirely disabled.

See #102.