### PR TITLE
Build for different platforms during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
           - { os: macos-latest, target: 'x86_64-apple-darwin' }
           - { os: macos-latest, target: 'aarch64-apple-darwin' }
           - { os: windows-latest, target: 'x86_64-pc-windows-msvc' }
-          - { os: windows-latest, target: 'i686-pc-windows-msvc' }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
 
 jobs:
@@ -13,6 +16,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
   clippy_correctness_checks:
     runs-on: ubuntu-latest
     name: Clippy correctness checks
@@ -33,3 +37,47 @@ jobs:
         with:
           command: clippy
           args: -- -W clippy::correctness -D warnings
+
+  build:
+    name: Build
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-latest, target: 'x86_64-unknown-linux-gnu' }
+          - { os: macos-latest, target: 'x86_64-apple-darwin' }
+          - { os: macos-latest, target: 'aarch64-apple-darwin' }
+          - { os: windows-latest, target: 'x86_64-pc-windows-msvc' }
+          - { os: windows-latest, target: 'i686-pc-windows-msvc' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            --allow-unauthenticated -y -qq \
+              libasound2-dev \
+              libudev-dev
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.config.target }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --locked --target ${{ matrix.config.target }}


### PR DESCRIPTION
This PR extends the continuous integration workflow to add a build check for different platforms. It is for making sure that the game builds fine for each push to `master`.
