### PR TITLE
Add GitHub workflow for automated binary releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,125 @@
+name: CD
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build_release:
+    name: Build release binaries
+    runs-on: ${{ matrix.config.os }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-latest, target: 'x86_64-unknown-linux-gnu' }
+          - { os: macos-latest, target: 'x86_64-apple-darwin' }
+          - { os: macos-latest, target: 'aarch64-apple-darwin' }
+          - { os: windows-latest, target: 'x86_64-pc-windows-msvc' }
+          - { os: windows-latest, target: 'i686-pc-windows-msvc' }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set the release version
+        shell: bash
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        if: matrix.config.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            --allow-unauthenticated -y -qq \
+              libasound2-dev \
+              libudev-dev
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.config.target }}
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --locked --target ${{ matrix.config.target }}
+
+      - name: Prepare artifacts [Windows]
+        shell: bash
+        if: matrix.config.os == 'windows-latest'
+        run: |
+          release_dir="punchy-${{ env.RELEASE_VERSION }}"
+          artifact_path="punchy-${{ env.RELEASE_VERSION }}-${{ matrix.config.target }}.zip"
+          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
+          mkdir $release_dir
+          cp target/${{ matrix.config.target }}/release/punchy.exe $release_dir/
+          cp -R assets/ $release_dir/
+          cp LICENSE.md $release_dir/
+          7z a -tzip $artifact_path $release_dir/
+
+      - name: Prepare artifacts [Unix]
+        shell: bash
+        if: matrix.config.os != 'windows-latest'
+        run: |
+          release_dir="punchy-${{ env.RELEASE_VERSION }}"
+          artifact_path="punchy-${{ env.RELEASE_VERSION }}-${{ matrix.config.target }}.tar.gz"
+          echo "ARTIFACT_PATH=$artifact_path" >> $GITHUB_ENV
+          mkdir $release_dir
+          cp target/${{ matrix.config.target }}/release/punchy $release_dir/
+          cp -R assets $release_dir
+          cp LICENSE.md $release_dir
+          tar -czvf $artifact_path $release_dir/
+
+      - name: Deploy | Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.ARTIFACT_PATH }}
+          path: ${{ env.ARTIFACT_PATH }}
+          if-no-files-found: error
+
+  publish_release:
+    name: Create and Publish GitHub Release
+    needs: build_release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Set the release version
+        shell: bash
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+
+      - name: Generate Checksums
+        run: for file in punchy-*/punchy-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
+
+      - name: Publish Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          release_name: Release ${{ env.RELEASE_VERSION }}
+          file: punchy-*/punchy-*
+          file_glob: true
+          overwrite: true
+          body: 'Punchy ${{ env.RELEASE_VERSION }} 🐟'
+          tag: ${{ github.ref }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,6 @@ jobs:
           - { os: macos-latest, target: 'x86_64-apple-darwin' }
           - { os: macos-latest, target: 'aarch64-apple-darwin' }
           - { os: windows-latest, target: 'x86_64-pc-windows-msvc' }
-          - { os: windows-latest, target: 'i686-pc-windows-msvc' }
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds a release workflow for creating binary archives when a tag is pushed. It is required for the launcher, see #103

As an example, see the release assets created on my fork: https://github.com/orhun/punchy/releases/tag/v0.0.3
