### PR TITLE
Implement player movements clamping (currently, via helper function)

### DIFF
--- a/src/movement.rs
+++ b/src/movement.rs
@@ -313,11 +313,7 @@ pub fn clamp_player_movements(
             let new_movement = movement.map(|mut movement| {
                 let new_x = location.x + movement.x;
 
-                // The dir.x condition allows some flexibility (e.g. in case of knockback), given
-                // the current state of development. To be removed once the movement logic is
-                // stabilized.
-                //
-                if movement.x < 0. && new_x < left_movement_boundary.0 {
+                if new_x < left_movement_boundary.0 {
                     movement.x = 0.;
                 }
 

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -1,6 +1,6 @@
 use bevy::{
     core::{Time, Timer},
-    math::{Quat, Vec2},
+    math::{Quat, Vec2, Vec3},
     prelude::{
         Commands, Component, Deref, DerefMut, Entity, EventWriter, Query, Res, ResMut, Transform,
         With,
@@ -68,74 +68,30 @@ pub fn player_controller(
     game_meta: Res<GameMeta>,
     left_movement_boundary: Res<LeftMovementBoundary>,
 ) {
-    let players_x = query
-        .iter()
-        .map(|(_, _, transform, _, _)| transform.translation.x)
-        .collect::<Vec<_>>();
-
     // Compute the new direction vectors; can be None if the state is not (idle or running).
     //
-    let mut player_dirs = query
+    let player_movements = query
         .iter()
         .map(|(state, stats, transform, _, input)| {
             if *state != State::Idle && *state != State::Running {
-                None
+                (transform.translation, None)
             } else {
-                let mut dir = Vec2::ZERO;
-
-                if input.pressed(PlayerAction::Move) {
-                    dir = input.axis_pair(PlayerAction::Move).unwrap().xy();
-                }
+                let mut dir = if input.pressed(PlayerAction::Move) {
+                    input.axis_pair(PlayerAction::Move).unwrap().xy()
+                } else {
+                    Vec2::ZERO
+                };
 
                 // Apply speed
                 dir = dir * stats.movement_speed * time.delta_seconds();
 
-                let new_x = transform.translation.x + dir.x;
-
-                // The dir.x condition allows some flexibility (e.g. in case of knockback), given
-                // the current state of development. To be removed once the movement logic is
-                // stabilized.
-                //
-                if dir.x < 0. && new_x < left_movement_boundary.0 {
-                    dir.x = 0.;
-                }
-
-                //Restrict player to the ground
-                let new_y = transform.translation.y + dir.y + consts::GROUND_OFFSET;
-
-                if new_y >= consts::MAX_Y || new_y <= consts::MIN_Y {
-                    dir.y = 0.;
-                }
-
                 //Move the player
-                Some(dir)
+                (transform.translation, Some(dir))
             }
         })
         .collect::<Vec<_>>();
 
-    if player_dirs.len() > 1 {
-        let max_players_x_distance =
-            LEFT_BOUNDARY_MAX_DISTANCE + game_meta.camera_move_right_boundary;
-
-        let new_players_x = players_x
-            .iter()
-            .zip(player_dirs.iter())
-            .map(|(x, dir)| x + dir.unwrap_or(Vec2::ZERO).x)
-            .collect::<Vec<_>>();
-
-        let min_player_x = new_players_x
-            .iter()
-            .min_by(|ax, bx| ax.total_cmp(bx))
-            .unwrap();
-
-        for (player_dir, player_x) in player_dirs.iter_mut().zip(new_players_x.iter()) {
-            if let Some(player_dir) = player_dir.as_mut() {
-                if *player_x > min_player_x + max_players_x_distance {
-                    *player_dir = Vec2::ZERO;
-                }
-            }
-        }
-    }
+    let player_dirs = clamp_player_movements(player_movements, &left_movement_boundary, &game_meta);
 
     for ((mut state, _, mut transform, mut facing, _), dir) in
         query.iter_mut().zip(player_dirs.iter())
@@ -289,4 +245,77 @@ pub fn update_left_movement_boundary(
             .0
             .max(max_player_x - game_meta.camera_move_right_boundary - LEFT_BOUNDARY_MAX_DISTANCE);
     }
+}
+
+/// Returns the direction vectors, with X/Y clamping.
+///
+/// Not a system, but a utility method!.
+///
+/// player_movements: array of (location, direction vector).
+///
+/// WATCH OUT! All players must be included, even if they don't move, in which case, pass
+/// None as direction. This is because clamping is based on the position of _all_ the
+/// players.
+/// It's possible to pass an empty array; this can happen if the system doesn't guard the case
+/// where all the players are dead; an empty array will be returned.
+pub fn clamp_player_movements(
+    player_movements: Vec<(Vec3, Option<Vec2>)>,
+    left_movement_boundary: &LeftMovementBoundary,
+    game_meta: &GameMeta,
+) -> Vec<Option<Vec2>> {
+    // In the first pass, we perform the absolute clamping (screen limits), and we collect the data
+    // required for the relative clamping.
+
+    let mut min_new_player_x = f32::MAX;
+
+    let player_movements = player_movements
+        .iter()
+        .map(|(location, movement)| {
+            let new_movement = movement.map(|mut movement| {
+                let new_x = location.x + movement.x;
+
+                // The dir.x condition allows some flexibility (e.g. in case of knockback), given
+                // the current state of development. To be removed once the movement logic is
+                // stabilized.
+                //
+                if movement.x < 0. && new_x < left_movement_boundary.0 {
+                    movement.x = 0.;
+                }
+
+                //Restrict player to the ground
+                let new_y = location.y + movement.y + consts::GROUND_OFFSET;
+
+                if new_y >= consts::MAX_Y || new_y <= consts::MIN_Y {
+                    movement.y = 0.;
+                }
+
+                (movement, new_x)
+            });
+
+            if let Some((_, new_x)) = new_movement {
+                min_new_player_x = min_new_player_x.min(new_x);
+            } else {
+                min_new_player_x = min_new_player_x.min(location.x);
+            }
+
+            (location, new_movement)
+        })
+        .collect::<Vec<_>>();
+
+    // Then, we perform the clamping of the players relative to each other.
+
+    let max_players_x_distance = LEFT_BOUNDARY_MAX_DISTANCE + game_meta.camera_move_right_boundary;
+
+    player_movements
+        .iter()
+        .map(|(_, player_movement)| {
+            player_movement.map(|(player_dir, new_player_x)| {
+                if new_player_x > min_new_player_x + max_players_x_distance {
+                    Vec2::ZERO
+                } else {
+                    player_dir
+                }
+            })
+        })
+        .collect::<Vec<_>>()
 }


### PR DESCRIPTION
Clamp the player movements/attacks, currently via function. Once the multistage design is implemented, this can be easily split (which will actually simplify the code).

I'm marking this as closes #63 and closes #133, as this effectively fixes the problem. Once the multistage is in place, intention to move is essentially a refactoring.