### PR TITLE
Implement Load Progress Tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3170,6 +3170,7 @@ dependencies = [
  "getrandom",
  "iyes_loopless",
  "leafwing_input_manager",
+ "punchy_macros",
  "rand",
  "serde",
  "serde_yaml",
@@ -3178,6 +3179,15 @@ dependencies = [
  "thiserror",
  "unic-langid",
  "web-sys",
+]
+
+[[package]]
+name = "punchy_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,15 @@ authors = ["The Fish Fight Game & Spicy Lobster Developers"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 
+[workspace]
+members = [
+    ".",
+    "macros"
+]
+
 [dependencies]
+punchy_macros = { path = "./macros" }
+
 anyhow = "1.0.58"
 bevy = "0.7.0"
 bevy-parallax = "0.1.2"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "punchy_macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0.98"
+quote = "1.0.20"
+proc-macro2 = "1.0.42"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,111 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, quote_spanned};
+use syn::{parse_quote, spanned::Spanned};
+
+/// Derive macro for `HasLoadProgress`
+///
+/// May be used to implement `HasLoadProgress` on structs where all fields implement
+/// `HasLoadProgress`.
+///
+/// Fields not implementing `HasLoadProgress` may be skipped with `#[has_load_progress(none)]` added
+/// to the field.
+///
+/// `#[has_load_progress(none)]` may also be added to the struct itself to use the default
+/// implementation of `HasLoadProgress` which returns no progress and nothing to load.
+///
+/// `#[has_load_progress(none)]` could also be added to enums to derive the default implementation
+/// with no load progress, but cannot be added to enum variants.
+#[proc_macro_derive(HasLoadProgress, attributes(has_load_progress))]
+pub fn has_load_progress(input: TokenStream) -> TokenStream {
+    let input = syn::parse(input).unwrap();
+
+    impl_has_load_progress(&input).into()
+}
+
+fn impl_has_load_progress(input: &syn::DeriveInput) -> TokenStream2 {
+    // The attribute that may be added to skip fields or use the default implementation.
+    let no_load_attr: syn::Attribute = parse_quote! {
+        #[has_load_progress(none)]
+    };
+
+    let item_ident = &input.ident;
+    let mut impl_function_body = quote! {};
+
+    // Check for `#[has_load_progress(none)]` on the item itself
+    let mut skip_all_fields = false;
+    for attr in &input.attrs {
+        if attr.path == parse_quote!(has_load_progress) {
+            if attr == &no_load_attr {
+                skip_all_fields = true;
+            } else {
+                return quote_spanned!(attr.span() =>
+                    compile_error!("Attribute must be `#[has_load_progress(none)]` if specified");
+                );
+            }
+        }
+    }
+
+    // If we are skipping all fields
+    if skip_all_fields {
+        impl_function_body = quote! {
+            crate::loading::progress::LoadProgress::default()
+        };
+
+    // If we should process struct fields
+    } else {
+        // Parse the struct
+        let in_struct = match &input.data {
+            syn::Data::Struct(s) => s,
+            syn::Data::Enum(_) | syn::Data::Union(_) => {
+                return quote_spanned! { input.ident.span() =>
+                    compile_error!("You may only derive HasLoadProgress on structs");
+                };
+            }
+        };
+
+        // Start a list of the progresses for each field
+        let mut progresses = Vec::new();
+        'field: for field in &in_struct.fields {
+            // Skip this field if it has `#[has_load_progress(none)]`
+            for attr in &field.attrs {
+                if attr.path == parse_quote!(has_load_progress) {
+                    if attr == &no_load_attr {
+                        continue 'field;
+                    } else {
+                        impl_function_body = quote_spanned! { attr.span() =>
+                            compile_error!("Attribute be `#[has_load_progress(none)]` if specified");
+                        }
+                    }
+                }
+            }
+
+            // Add this fields load progress to the list of progresses
+            let field_ident = field.ident.as_ref().expect("Field ident");
+            progresses.push(quote_spanned! { field_ident.span() =>
+                crate::loading::progress::HasLoadProgress::load_progress(
+                    &self.#field_ident,
+                    loading_resources
+                )
+            })
+        }
+
+        // Retrun the merged progress result
+        impl_function_body = quote! {
+            #impl_function_body
+            crate::loading::progress::LoadProgress::merged([ #( #progresses),* ])
+        };
+    }
+
+    // Fill out rest of impl block
+    quote! {
+        impl crate::loading::progress::HasLoadProgress for #item_ident {
+            fn load_progress(
+                &self,
+                loading_resources: &crate::loading::progress::LoadingResources
+            ) -> crate::loading::progress::LoadProgress {
+                #impl_function_body
+            }
+        }
+    }
+}

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -168,15 +168,6 @@ impl AssetLoader for LevelMetaLoader {
 
             let self_path = load_context.path();
 
-            // Convert all parallax paths to relative asset paths so that the convention matches the
-            // rest of the paths used by the asset loaders.
-            for layer in &mut meta.parallax_background.layers {
-                layer.path = relative_asset_path(self_path, &layer.path)
-                    .to_str()
-                    .unwrap()
-                    .to_owned();
-            }
-
             let mut dependencies = Vec::new();
 
             // Load the players
@@ -207,8 +198,24 @@ impl AssetLoader for LevelMetaLoader {
                 item.item_handle = item_handle;
             }
 
-            // Load the music
+            // Load parallax background layers
+            for layer in &mut meta.parallax_background.layers {
+                let (path, handle) = get_relative_asset(load_context, self_path, &layer.path);
 
+                // Update the layer path to use an absolute path so that it matches the conventione
+                // used by the bevy_parallax_background plugin.
+                layer.path = path
+                    .path()
+                    .as_os_str()
+                    .to_str()
+                    .expect("utf8-filename")
+                    .to_string();
+
+                layer.image_handle = handle;
+                dependencies.push(path);
+            }
+
+            // Load the music
             let (music_path, music_handle) =
                 get_relative_asset(load_context, self_path, &meta.music);
             meta.music_handle = music_handle;

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -105,15 +105,33 @@ impl AssetLoader for GameMetaLoader {
             meta.main_menu.background_image.image_handle = main_menu_background;
             dependencies.push(main_menu_background_path);
 
-            // Load the music
+            // Load UI border images
+            let mut load_border_image = |border: &mut BorderImageMeta| {
+                let (path, handle) = get_relative_asset(load_context, &self_path, &border.image);
+                dependencies.push(path);
+                border.handle = handle;
+            };
+            load_border_image(&mut meta.ui_theme.hud.portrait_frame);
+            load_border_image(&mut meta.ui_theme.panel.border);
+            load_border_image(&mut meta.ui_theme.hud.lifebar.background_image);
+            load_border_image(&mut meta.ui_theme.hud.lifebar.progress_image);
+            for button in meta.ui_theme.button_styles.values_mut() {
+                load_border_image(&mut button.borders.default);
+                if let Some(border) = &mut button.borders.clicked {
+                    load_border_image(border);
+                }
+                if let Some(border) = &mut button.borders.focused {
+                    load_border_image(border);
+                }
+            }
 
+            // Load the music
             let (music_path, music_handle) =
                 get_relative_asset(load_context, &self_path, &meta.main_menu.music);
             meta.main_menu.music_handle = music_handle;
             dependencies.push(music_path);
 
             // Load UI fonts
-
             for (font_name, font_relative_path) in &meta.ui_theme.font_families {
                 let (font_path, font_handle) =
                     get_relative_asset(load_context, &self_path, font_relative_path);

--- a/src/loading/progress.rs
+++ b/src/loading/progress.rs
@@ -85,7 +85,7 @@ macro_rules! impl_default_load_progress {
         )*
     };
 }
-impl_default_load_progress!(String, f32, u32, Vec2, Vec3, UVec2, egui::TextureId);
+impl_default_load_progress!(String, f32, usize, u32, Vec2, Vec3, UVec2, egui::TextureId);
 
 // Implement `HasLoadProgress` for container types
 impl<T: HasLoadProgress> HasLoadProgress for Option<T> {

--- a/src/loading/progress.rs
+++ b/src/loading/progress.rs
@@ -1,0 +1,107 @@
+//! Loading progress types and traits
+
+use std::marker::PhantomData;
+
+use bevy::{
+    asset::{Asset, LoadState},
+    ecs::system::SystemParam,
+    math::{UVec2, Vec2, Vec3},
+    prelude::{AssetServer, Handle, Res},
+    utils::HashMap,
+};
+use bevy_egui::egui;
+
+/// A progress indicator holding how many items must be loaded and how many items have been loaded
+#[derive(Clone, Copy, Default, Debug)]
+pub struct LoadProgress {
+    pub loaded: u32,
+    pub total: u32,
+}
+
+impl std::fmt::Display for LoadProgress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} / {}", self.loaded, self.total)
+    }
+}
+
+impl LoadProgress {
+    /// Get the load progress as a percentage
+    pub fn as_percent(&self) -> f32 {
+        self.loaded as f32 / self.total as f32
+    }
+
+    /// Get a total load progress from an iterator of [`LoadProgress`]s
+    pub fn merged<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = LoadProgress>,
+    {
+        let mut loaded = 0;
+        let mut total = 0;
+        for progress in iter {
+            loaded += progress.loaded;
+            total += progress.total;
+        }
+
+        Self { loaded, total }
+    }
+}
+
+/// System param containing Bevy resources that may be used to determine load progress
+///
+/// Currently this only contains the bevy asset server, but this may additionally contain the
+/// scripting engine once script loading is implemented.
+#[derive(SystemParam)]
+pub struct LoadingResources<'w, 's> {
+    asset_server: Res<'w, AssetServer>,
+    #[system_param(ignore)]
+    _phantom: PhantomData<&'s ()>,
+}
+
+/// Trait implemented on items that can report their load progress from the [`LoadingResources`].
+pub trait HasLoadProgress {
+    // Default implementation returns no progress and nothing to load
+    fn load_progress(&self, _loading_resources: &LoadingResources) -> LoadProgress {
+        LoadProgress::default()
+    }
+}
+
+// Implement `HasLoadProgress` for asset handles
+impl<T: Asset> HasLoadProgress for Handle<T> {
+    fn load_progress(&self, loading_resources: &LoadingResources) -> LoadProgress {
+        let loaded = loading_resources.asset_server.get_load_state(self) == LoadState::Loaded;
+
+        LoadProgress {
+            loaded: if loaded { 1 } else { 0 },
+            total: 1,
+        }
+    }
+}
+
+// Impelement default `HasLoadProgress` for various basic types
+macro_rules! impl_default_load_progress {
+    ( $($type:ty),* ) => {
+        $(
+            impl HasLoadProgress for $type {}
+        )*
+    };
+}
+impl_default_load_progress!(String, f32, u32, Vec2, Vec3, UVec2, egui::TextureId);
+
+// Implement `HasLoadProgress` for container types
+impl<T: HasLoadProgress> HasLoadProgress for Option<T> {
+    fn load_progress(&self, loading_resources: &LoadingResources) -> LoadProgress {
+        self.as_ref()
+            .map(|x| x.load_progress(loading_resources))
+            .unwrap_or_default()
+    }
+}
+impl<T: HasLoadProgress> HasLoadProgress for Vec<T> {
+    fn load_progress(&self, loading_resources: &LoadingResources) -> LoadProgress {
+        LoadProgress::merged(self.iter().map(|x| x.load_progress(loading_resources)))
+    }
+}
+impl<K, T: HasLoadProgress> HasLoadProgress for HashMap<K, T> {
+    fn load_progress(&self, loading_resources: &LoadingResources) -> LoadProgress {
+        LoadProgress::merged(self.values().map(|x| x.load_progress(loading_resources)))
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -148,7 +148,6 @@ pub struct ItemSpawnMeta {
 
 #[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
-#[has_load_progress(none)]
 pub struct ParallaxMeta {
     pub layers: Vec<ParallaxLayerMeta>,
 }
@@ -159,12 +158,13 @@ impl ParallaxMeta {
     }
 }
 
-// TODO: This struct is a workaround for the fact that `bevy_parallax::LayerData` isn't Clone.
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ParallaxLayerMeta {
     pub speed: f32,
     pub path: String,
+    #[serde(skip)]
+    pub image_handle: Handle<Image>,
     pub tile_size: Vec2,
     pub cols: usize,
     pub rows: usize,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -8,6 +8,7 @@ use bevy::{
 use bevy_egui::egui;
 use bevy_kira_audio::AudioSource;
 use bevy_parallax::{LayerData, ParallaxResource};
+use punchy_macros::HasLoadProgress;
 use serde::Deserialize;
 
 use crate::{animation::Clip, assets::EguiFont, state::State, Stats};
@@ -21,7 +22,7 @@ pub mod ui;
 pub mod localization;
 pub use localization::TranslationsMeta;
 
-#[derive(TypeUuid, Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, TypeUuid, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 #[uuid = "eb28180f-ef68-44a0-8479-a299a3cef66e"]
 pub struct GameMeta {
@@ -37,7 +38,7 @@ pub struct GameMeta {
     pub translations: TranslationsMeta,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct MainMenuMeta {
     pub title_font: FontMeta,
@@ -47,7 +48,7 @@ pub struct MainMenuMeta {
     pub music_handle: Handle<AudioSource>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ImageMeta {
     pub image: String,
@@ -56,10 +57,11 @@ pub struct ImageMeta {
     pub image_handle: Handle<Image>,
 }
 
-#[derive(TypeUuid, Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, TypeUuid, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 #[uuid = "32111f6e-bb9a-4ea7-8988-1220b923a059"]
 pub struct LevelMeta {
+    #[has_load_progress(none)]
     pub background_color: [u8; 3],
     pub parallax_background: ParallaxMeta,
     pub players: Vec<FighterSpawnMeta>,
@@ -125,7 +127,7 @@ pub struct AudioMeta {
     pub effect_handles: HashMap<State, HashMap<usize, Handle<AudioSource>>>,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FighterSpawnMeta {
     pub fighter: String,
@@ -134,7 +136,7 @@ pub struct FighterSpawnMeta {
     pub location: Vec3,
 }
 
-#[derive(TypeUuid, Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, TypeUuid, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 #[uuid = "f5092550-ec30-013a-92a9-2cf05d71216b"]
 pub struct ItemSpawnMeta {
@@ -144,8 +146,9 @@ pub struct ItemSpawnMeta {
     pub location: Vec3,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
+#[has_load_progress(none)]
 pub struct ParallaxMeta {
     pub layers: Vec<ParallaxLayerMeta>,
 }

--- a/src/metadata/localization.rs
+++ b/src/metadata/localization.rs
@@ -6,13 +6,15 @@ use unic_langid::LanguageIdentifier;
 
 use super::*;
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct TranslationsMeta {
     /// The locale setting detected on the user's system
     #[serde(skip)]
+    #[has_load_progress(none)]
     pub detected_locale: LanguageIdentifier,
     /// The default locale that will be used if a message is not found in the user's selected locale
+    #[has_load_progress(none)]
     pub default_locale: LanguageIdentifier,
     /// Paths to the locale resources to load
     pub locales: Vec<String>,

--- a/src/metadata/settings.rs
+++ b/src/metadata/settings.rs
@@ -1,11 +1,13 @@
 use bevy::prelude::Gamepad;
 use leafwing_input_manager::{axislike::VirtualDPad, prelude::InputMap, user_input::InputKind};
+use punchy_macros::HasLoadProgress;
 use serde::{Deserialize, Serialize};
 
 use crate::input::PlayerAction;
 
 /// Global settings, stored and accessed through [`crate::platform::Storage`]
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(HasLoadProgress, Deserialize, Serialize, Debug, Clone)]
+#[has_load_progress(none)]
 pub struct Settings {
     // The player controller bindings
     pub player_controls: PlayerControlMethods,

--- a/src/metadata/ui.rs
+++ b/src/metadata/ui.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use super::*;
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct UIThemeMeta {
     pub font_families: HashMap<String, String>,
@@ -51,8 +51,9 @@ impl From<String> for FontFamily {
     }
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
+#[has_load_progress(none)]
 pub struct FontMeta {
     pub family: FontFamily,
     pub size: f32,
@@ -98,7 +99,7 @@ impl TryFrom<String> for ButtonStyle {
     }
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct HudThemeMeta {
     pub player_hud_width: f32,
@@ -107,7 +108,7 @@ pub struct HudThemeMeta {
     pub lifebar: ProgressBarMeta,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct PanelThemeMeta {
     #[serde(default)]
@@ -117,7 +118,7 @@ pub struct PanelThemeMeta {
     pub border: BorderImageMeta,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ButtonThemeMeta {
     pub font: FontMeta,
@@ -126,7 +127,7 @@ pub struct ButtonThemeMeta {
     pub borders: ButtonBordersMeta,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct BorderImageMeta {
     pub image: String,
@@ -146,7 +147,7 @@ fn f32_one() -> f32 {
     1.0
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ProgressBarMeta {
     pub height: f32,
@@ -154,7 +155,7 @@ pub struct ProgressBarMeta {
     pub progress_image: BorderImageMeta,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(HasLoadProgress, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ButtonBordersMeta {
     pub default: BorderImageMeta,
@@ -164,8 +165,9 @@ pub struct ButtonBordersMeta {
     pub clicked: Option<BorderImageMeta>,
 }
 
-#[derive(Default, Deserialize, Clone, Copy, Debug)]
+#[derive(HasLoadProgress, Default, Deserialize, Clone, Copy, Debug)]
 #[serde(deny_unknown_fields)]
+#[has_load_progress(none)]
 pub struct ColorMeta([u8; 3]);
 
 impl From<ColorMeta> for egui::Color32 {
@@ -175,7 +177,7 @@ impl From<ColorMeta> for egui::Color32 {
     }
 }
 
-#[derive(Default, Deserialize, Clone, Copy, Debug)]
+#[derive(HasLoadProgress, Default, Deserialize, Clone, Copy, Debug)]
 #[serde(deny_unknown_fields, default)]
 pub struct MarginMeta {
     #[serde(default)]


### PR DESCRIPTION
Loading screen still needs to be implemented.

This PR implements a solution for tracking the load progress of game assets.

This works towards #161, but it doesn't implement the UI yet, just the load progress tracking.

It allows us to get the load progress for both `GameMeta` and `LevelMeta` and adds logic to wait until game and level assets are loaded before starting the game/level. This time period should be replaced with a loading screen in a subsequent PR.

#### Why This is So Complicated

Tracking the loading progress for the game is not trivial due to the fact that we have _several_ different kinds of asset and handles referenced throughout the `GameMeta` struct at many different levels of struct nesting.

My initial thought was to add a simple function where I simply manually return all the `HandleId`s in the various different parts of the `GameMeta` struct in a vector. This instantly became very difficult because of how spread out between types the handles are. There wasn't a good way to know if I had gotten all the handles, and if we added more handles later, we would have to remember to update the list which would be horrible to manage and would almost surely become out of date.

Instead, in this PR I added a `HasLoadProgress` trait that we use a custom derive macro to derive on `GameMeta` and all of the structs that it contains. This ensures that _all_ of the handles contained in the `GameMeta` struct will be properly evaluated when checking load progress and it doesn't require difficult manual listing of handles.

The cost is that we write a macro and add a macro crate to our codebase, but this took me less than a day, and it is a relatively simple macro. I think it turned out rather elegant and I don't know of any other reasonable alternative at this point, but let me know if you have other thoughts!