### PR TITLE
Use Separate Cargo Target Dir for Web Builds

### DIFF
--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -41,6 +41,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages
-          folder: target/wasm-dist
+          folder: web-target/web-dist
           target-folder: demo
           ssh-key: ${{ secrets.MASTER_GH_PAGES_DEPLOY_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/web-target
 .cargo

--- a/justfile
+++ b/justfile
@@ -13,22 +13,22 @@ build:
 build-release:
     cargo build --release
 
-build-web:
+build-web $CARGO_TARGET_DIR='web-target':
     cargo build --target wasm32-unknown-unknown
-    wasm-bindgen --out-dir target/wasm --target web target/wasm32-unknown-unknown/debug/punchy.wasm
-    cat wasm_resources/index.html | sed "s/\$BASEPATH//g" > target/wasm/index.html
-    mkdir -p target/wasm
-    cp -r assets target/wasm/
+    wasm-bindgen --out-dir $CARGO_TARGET_DIR/web-dist --target web $CARGO_TARGET_DIR/wasm32-unknown-unknown/debug/punchy.wasm
+    cat wasm_resources/index.html | sed "s/\$BASEPATH//g" > $CARGO_TARGET_DIR/web-dist/index.html
+    mkdir -p target/web-dist
+    cp -r assets $CARGO_TARGET_DIR/web-dist/
 
-build-release-web basepath='':
+build-release-web basepath='' $CARGO_TARGET_DIR='web-target':
     cargo build --target wasm32-unknown-unknown --release
-    wasm-bindgen --out-dir target/wasm-dist --no-typescript --target web target/wasm32-unknown-unknown/release/punchy.wasm
-    cat wasm_resources/index.html | sed "s/\$BASEPATH/$(printf {{basepath}} | sed 's/\//\\\//g')/g" > target/wasm-dist/index.html
-    cp -r assets target/wasm-dist/
+    wasm-bindgen --out-dir $CARGO_TARGET_DIR/web-dist --no-typescript --target web $CARGO_TARGET_DIR/wasm32-unknown-unknown/release/punchy.wasm
+    cat wasm_resources/index.html | sed "s/\$BASEPATH/$(printf {{basepath}} | sed 's/\//\\\//g')/g" > $CARGO_TARGET_DIR/web-dist/index.html
+    cp -r assets $CARGO_TARGET_DIR/web-dist/
 
 run *args:
     cargo run -- {{args}}
 
 run-web port='4000' host='127.0.0.1': build-web
     @echo "Debug link: http://{{host}}:{{port}}?RUST_LOG=debug"
-    basic-http-server -a '{{host}}:{{port}}' -x target/wasm
+    basic-http-server -a '{{host}}:{{port}}' -x web-target/web-dist


### PR DESCRIPTION
This helps during local development because using separate target dirs
lets you build one without making your restart the build when you switch
to building the other again.