### PR TITLE
temp fix for attack frames

### DIFF
--- a/assets/fighters/bandit/bandit.fighter.yaml
+++ b/assets/fighters/bandit/bandit.fighter.yaml
@@ -34,7 +34,7 @@ spritesheet:
       frames: [0, 3]
       repeat: false
     attacking:
-      frames: [14, 16]
+      frames: [14, 17]
 
 audio:
   effects:

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -432,9 +432,9 @@ fn enemy_attack(
                         ))
                         .insert(Attack { damage: 10 })
                         .insert(AttackFrames {
-                            startup: 2,
-                            active: 3,
-                            recovery: 4,
+                            startup: 1,
+                            active: 2,
+                            recovery: 3,
                         })
                         .id();
                     commands.entity(event.0).push_children(&[attack_entity]);


### PR DESCRIPTION
Spritesheet changing animation frames caused breakage with hitbox despawning on attacks fixed here.