### PR TITLE
Remove Strip Flag in Release Profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ debug = false
 # slower than opt-level=0.
 
 [profile.release]
-strip = true
 lto = true
 codegen-units = 1 # Improves physics performance for release builds
 


### PR DESCRIPTION
This was breaking WASM release builds. Also I think we may want to leave
it out anyway, because stripping removes panic info that we probably
want, at least this early in development.

Fixes #167 