### PR TITLE
Web Build & CI Improvements

### DIFF
--- a/.github/workflows/web-demo.yml
+++ b/.github/workflows/web-demo.yml
@@ -3,7 +3,6 @@ name: Publish Web Demo
 on:
   push:
     tags:
-      - web-demo
       - 'v*'
 jobs:
   publish-web-demo:
@@ -34,13 +33,29 @@ jobs:
         with:
           version: '0.2.81'
 
-      - name: Build WASM Dist 🔨
-        run: just build-release-web /punchy/demo
+      - name: Build WASM Release 🔨
+        run: just build-release-web
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.3
         with:
           branch: gh-pages
-          folder: target/wasm-dist
-          target-folder: demo
+          folder: web-target/wasm-release
+          target-folder: player/${{ github.ref_name }}
           ssh-key: ${{ secrets.MASTER_GH_PAGES_DEPLOY_KEY }}
+
+      - name: Symlink Latest Build
+        run: |
+          mkdir latest-symlink-dir
+          ln -s ./${{ github.ref_name }} latest
+          mv latest latest-symlink-dir
+
+      - name: Deploy Symlinked Latest Build 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.3
+        with:
+          branch: gh-pages
+          folder: latest-symlink-dir
+          clean: false
+          target-folder: player
+          ssh-key: ${{ secrets.MASTER_GH_PAGES_DEPLOY_KEY }}
+      

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/web-target
 .cargo

--- a/justfile
+++ b/justfile
@@ -13,22 +13,19 @@ build:
 build-release:
     cargo build --release
 
-build-web:
-    cargo build --target wasm32-unknown-unknown
-    wasm-bindgen --out-dir target/wasm --target web target/wasm32-unknown-unknown/debug/punchy.wasm
-    cat wasm_resources/index.html | sed "s/\$BASEPATH//g" > target/wasm/index.html
-    mkdir -p target/wasm
-    cp -r assets target/wasm/
+build-web basepath='':
+    ./scripts/build-web.sh
 
 build-release-web basepath='':
-    cargo build --target wasm32-unknown-unknown --release
-    wasm-bindgen --out-dir target/wasm-dist --no-typescript --target web target/wasm32-unknown-unknown/release/punchy.wasm
-    cat wasm_resources/index.html | sed "s/\$BASEPATH/$(printf {{basepath}} | sed 's/\//\\\//g')/g" > target/wasm-dist/index.html
-    cp -r assets target/wasm-dist/
+    ./scripts/build-web.sh release
 
 run *args:
     cargo run -- {{args}}
 
 run-web port='4000' host='127.0.0.1': build-web
     @echo "Debug link: http://{{host}}:{{port}}?RUST_LOG=debug"
-    basic-http-server -a '{{host}}:{{port}}' -x target/wasm
+    basic-http-server -a '{{host}}:{{port}}' -x web-target/wasm-debug
+
+run-release-web port='4000' host='127.0.0.1': build-release-web
+    @echo "Debug link: http://{{host}}:{{port}}?RUST_LOG=debug"
+    basic-http-server -a '{{host}}:{{port}}' -x web-target/wasm-release

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -1,0 +1,30 @@
+#!/bin/env bash
+
+#
+# This script is usually run by the justfile
+#
+
+is_release="$1"
+target=wasm32-unknown-unknown
+target_dir="web-target"
+
+release_arg=""
+build_kind="debug"
+dist_dir="$target_dir/wasm-debug"
+
+if [ "$is_release" == "release" ]; then
+    release_arg="--release"
+    build_kind="release"
+    dist_dir="$target_dir/wasm-release"
+fi
+
+export CARGO_TARGET_DIR=$target_dir
+
+set -x
+
+cargo build --target $target $release_arg
+rm -rf $dist_dir
+mkdir -p $dist_dir
+wasm-bindgen --out-dir $dist_dir --target web --no-typescript $target_dir/$target/$build_kind/punchy.wasm
+cp wasm_resources/index.html $dist_dir/index.html
+cp -r assets $dist_dir

--- a/wasm_resources/index.html
+++ b/wasm_resources/index.html
@@ -136,7 +136,7 @@
       })();
     </script>
     <script type="module">
-      import init from "$BASEPATH/punchy.js";
+      import init from "./punchy.js";
       init();
     </script>
   </body>


### PR DESCRIPTION
- Make web build use it's own target folder to streamline local
development of both native and web builds.
- Make web build URL path agnostic so it can be hosted under any path.
- Make web player build in CI use different paths for each release along
with a latest path that symlinks to the latest release.