### PR TITLE
Make Web Build Script Exit Early on Failure

### DIFF
--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -20,7 +20,7 @@ fi
 
 export CARGO_TARGET_DIR=$target_dir
 
-set -x
+set -ex
 
 cargo build --target $target $release_arg
 rm -rf $dist_dir


### PR DESCRIPTION
Just a slight tweak that doesn't effect much, but makes sure we don't try to run `wasm-bindgen` if `cargo build` fails.