### PR TITLE
Move EngineConfig to a Static Global

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,6 +3170,7 @@ dependencies = [
  "getrandom",
  "iyes_loopless",
  "leafwing_input_manager",
+ "once_cell",
  "punchy_macros",
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ sys-locale = "0.2.1"
 fluent = "0.16.0"
 directories = "4.0.1"
 async-channel = "1.6.1"
+once_cell = "1.13.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = ["Window","Location","Storage"] }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -6,7 +6,7 @@ use bevy_kira_audio::{AudioChannel, AudioSource};
 
 use crate::{
     animation::Animation,
-    config::EngineConfig,
+    config::ENGINE_CONFIG,
     metadata::{GameMeta, LevelMeta},
     state::State,
 };
@@ -76,15 +76,11 @@ pub fn fighter_sound_effect(
     }
 }
 
-pub fn play_menu_music(
-    game_meta: Res<GameMeta>,
-    music_channel: Res<AudioChannel<MusicChannel>>,
-    engine_config: Res<EngineConfig>,
-) {
+pub fn play_menu_music(game_meta: Res<GameMeta>, music_channel: Res<AudioChannel<MusicChannel>>) {
     // This is a workaround for a Bevy Kira bug where stopping a sound immediately after
     // playing it doesn't work. We run into this issue when the menu starts and immediately
     // stops because the auto-start flag skips the menu. See issue #121 for context.
-    if !engine_config.auto_start {
+    if !ENGINE_CONFIG.auto_start {
         music_channel.play(game_meta.main_menu.music_handle.clone());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,15 @@
+use once_cell::sync::Lazy;
 use structopt::StructOpt;
 
 const DEFAULT_LOG_LEVEL: &str = "info,wgpu=error,bevy_fluent=warn,symphonia_core=warn,symphonia_format_ogg=warn,symphonia_bundle_mp3=warn";
+
+pub static ENGINE_CONFIG: Lazy<EngineConfig> = Lazy::new(|| {
+    #[cfg(not(target_arch = "wasm32"))]
+    return EngineConfig::from_args();
+
+    #[cfg(target_arch = "wasm32")]
+    return EngineConfig::from_web_params();
+});
 
 #[derive(Clone, Debug, StructOpt)]
 #[structopt(name = "Punchy", about = "A 2.5D side-scroller beatemup.")]

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -8,7 +8,7 @@ use rand::seq::SliceRandom;
 use crate::{
     animation::Animation,
     collisions::BodyLayers,
-    config::EngineConfig,
+    config::ENGINE_CONFIG,
     enemy::{Enemy, EnemyBundle},
     input::MenuAction,
     item::ItemBundle,
@@ -35,15 +35,6 @@ pub struct LoadingPlugin;
 
 impl Plugin for LoadingPlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(not(target_arch = "wasm32"))]
-        let engine_config = {
-            use structopt::StructOpt;
-            EngineConfig::from_args()
-        };
-
-        #[cfg(target_arch = "wasm32")]
-        let engine_config = EngineConfig::from_web_params();
-
         app.add_system(load_level.run_in_state(GameState::LoadingLevel))
             .add_system(
                 load_game
@@ -59,7 +50,7 @@ impl Plugin for LoadingPlugin {
             );
 
         // Configure hot reload
-        if engine_config.hot_reload {
+        if ENGINE_CONFIG.hot_reload {
             app.add_stage_after(
                 AssetStage::LoadAssets,
                 GameStage::HotReload,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ use ui::UIPlugin;
 use utils::ResetController;
 use y_sort::*;
 
-use crate::{config::EngineConfig, input::PlayerAction, item::pick_items};
+use crate::{input::PlayerAction, item::pick_items};
 
 #[cfg_attr(feature = "debug", derive(bevy_inspector_egui::Inspectable))]
 #[derive(Component, Deserialize, Clone, Debug)]
@@ -138,14 +138,9 @@ impl Default for PhysicsBundle {
 pub struct ArrivedEvent(Entity);
 
 fn main() {
-    #[cfg(not(target_arch = "wasm32"))]
-    let engine_config = {
-        use structopt::StructOpt;
-        EngineConfig::from_args()
-    };
-
-    #[cfg(target_arch = "wasm32")]
-    let engine_config = EngineConfig::from_web_params();
+    // Load engine config. This will parse CLI arguments or web query string so we want to do it
+    // before we create the app to make sure everything is in order.
+    let engine_config = &*config::ENGINE_CONFIG;
 
     let mut app = App::new();
     app.insert_resource(WindowDescriptor {
@@ -179,8 +174,7 @@ fn main() {
     app.add_plugins(DefaultPlugins);
 
     // Add other systems and resources
-    app.insert_resource(engine_config.clone())
-        .insert_resource(ClearColor(Color::BLACK))
+    app.insert_resource(ClearColor(Color::BLACK))
         .add_stage_after(
             CoreStage::Update,
             GameStage::Animation,
@@ -268,8 +262,8 @@ fn main() {
 
     // Get the game handle
     let asset_server = app.world.get_resource::<AssetServer>().unwrap();
-    let game_asset = engine_config.game_asset;
-    let game_handle: Handle<GameMeta> = asset_server.load(&game_asset);
+    let game_asset = &engine_config.game_asset;
+    let game_handle: Handle<GameMeta> = asset_server.load(game_asset);
 
     // Insert game handle resource
     app.world.insert_resource(game_handle);

--- a/src/ui/main_menu.rs
+++ b/src/ui/main_menu.rs
@@ -7,7 +7,7 @@ use leafwing_input_manager::{
 };
 
 use crate::{
-    config::EngineConfig,
+    config::ENGINE_CONFIG,
     input::MenuAction,
     metadata::{localization::LocalizationExt, ButtonStyle, FontStyle, GameMeta, Settings},
     platform::Storage,
@@ -99,7 +99,6 @@ pub struct MenuSystemParams<'w, 's> {
     commands: Commands<'w, 's>,
     game: Res<'w, GameMeta>,
     localization: Res<'w, Localization>,
-    engine_config: Res<'w, EngineConfig>,
     menu_input: Query<'w, 's, &'static mut ActionState<MenuAction>>,
     app_exit: EventWriter<'w, 's, AppExit>,
     storage: ResMut<'w, Storage>,
@@ -161,7 +160,6 @@ fn main_menu_ui(params: &mut MenuSystemParams, ui: &mut egui::Ui) {
         commands,
         game,
         localization,
-        engine_config,
         app_exit,
         storage,
         ..
@@ -186,7 +184,7 @@ fn main_menu_ui(params: &mut MenuSystemParams, ui: &mut egui::Ui) {
         .show(ui)
         .focus_by_default(ui);
 
-        if start_button.clicked() || engine_config.auto_start {
+        if start_button.clicked() || ENGINE_CONFIG.auto_start {
             commands.insert_resource(game.start_level_handle.clone());
             commands.insert_resource(NextState(GameState::LoadingLevel));
         }


### PR DESCRIPTION
EngineConfig is read-only and logically makes sense as a static as it
last the life of the program, so this moves it to a global static that
can be accessed from anywhere in the program instead of just in the Bevy
world.

This is also going to be required for scripting support so that the
asset directory will be readable from asset loaders without borrowing the
Bevy world.