### PR TITLE
Implement trip points

### DIFF
--- a/assets/beach/beach.level.yaml
+++ b/assets/beach/beach.level.yaml
@@ -52,16 +52,22 @@ players:
 enemies:
   - fighter: &slinger /fighters/slinger/slinger.fighter.yaml
     location: [325, 0, 0]
+    trip_point_x: -1
   - fighter: *slinger
     location: [225, 50, 0]
+    trip_point_x: -1
   - fighter: &bandit /fighters/bandit/bandit.fighter.yaml
     location: [225, -10, 0]
+    trip_point_x: -1
   - fighter: *bandit
     location: [275, -50, 0]
+    trip_point_x: -1
   - fighter: &brute /fighters/brute/brute.fighter.yaml
     location: [400, -30, 0]
+    trip_point_x: -1
   - fighter: *brute
     location: [450, 20, 0]
+    trip_point_x: 300
 
 items:
   - item: &bottle /items/bottle/bottle.item.yaml

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -7,9 +7,6 @@ pub const PLAYER_HEIGHT: f32 = PLAYER_SPRITE_HEIGHT - 50.;
 //
 pub const LEFT_BOUNDARY_MAX_DISTANCE: f32 = 380.;
 
-// In this style of game, considering Y is not significant.
-pub const ENEMY_FOV_X: f32 = 800.;
-
 pub const GROUND_Y: f32 = -120.;
 pub const GROUND_HEIGHT: f32 = 150.;
 pub const GROUND_OFFSET: f32 = 0.;

--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -9,6 +9,11 @@ use crate::{
 #[derive(Component)]
 pub struct Enemy;
 
+/// X coordinate of the level that requires to be trespassed in order for the enemies to move.
+/// For simplicy, once a given trip point is trespassed for the first time, it's set to f32::MIN.
+#[derive(Component)]
+pub struct TripPointX(pub f32);
+
 #[derive(Bundle)]
 pub struct EnemyBundle {
     enemy: Enemy,
@@ -16,6 +21,7 @@ pub struct EnemyBundle {
     #[bundle]
     transform_bundle: TransformBundle,
     fighter_handle: Handle<FighterMeta>,
+    trip_point_x: TripPointX,
 }
 
 impl EnemyBundle {
@@ -33,6 +39,7 @@ impl EnemyBundle {
             facing: Facing::Left,
             transform_bundle,
             fighter_handle,
+            trip_point_x: TripPointX(enemy_meta.trip_point_x.unwrap()),
         }
     }
 }

--- a/src/enemy.rs
+++ b/src/enemy.rs
@@ -39,7 +39,7 @@ impl EnemyBundle {
             facing: Facing::Left,
             transform_bundle,
             fighter_handle,
-            trip_point_x: TripPointX(enemy_meta.trip_point_x.unwrap()),
+            trip_point_x: TripPointX(enemy_meta.trip_point_x),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ use bevy::{asset::AssetServerSettings, ecs::bundle::Bundle, log::LogSettings, pr
 use bevy_kira_audio::{AudioApp, AudioPlugin};
 use bevy_parallax::{ParallaxPlugin, ParallaxResource};
 use bevy_rapier2d::prelude::*;
-use consts::ENEMY_FOV_X;
 use enemy::*;
 use input::MenuAction;
 use iyes_loopless::prelude::*;
@@ -329,25 +328,15 @@ fn game_over_on_players_death(
 //for enemys without current target, pick a new spot near the player as target
 fn set_target_near_player(
     mut commands: Commands,
-    query: Query<(Entity, &State, &Transform), (With<Enemy>, Without<Target>)>,
+    query: Query<(Entity, &State), (With<Enemy>, Without<Target>)>,
     player_query: Query<&Transform, With<Player>>,
 ) {
     let mut rng = rand::thread_rng();
-    let player_transforms = player_query.iter().collect::<Vec<_>>();
+    let transforms = player_query.iter().collect::<Vec<_>>();
 
-    for (entity, state, enemy_transform) in query.iter() {
+    for (entity, state) in query.iter() {
         if *state == State::Idle {
-            let in_view_player_transforms = player_transforms
-                .iter()
-                .filter(|transform| {
-                    (transform.translation - enemy_transform.translation)
-                        .x
-                        .abs()
-                        <= ENEMY_FOV_X
-                })
-                .collect::<Vec<_>>();
-
-            if let Some(player_transform) = in_view_player_transforms.choose(&mut rng) {
+            if let Some(player_transform) = transforms.choose(&mut rng) {
                 let x_offset = rng.gen_range(-100.0..100.);
                 let y_offset = rng.gen_range(-100.0..100.);
                 commands.entity(entity).insert(Target {

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,22 +328,21 @@ fn game_over_on_players_death(
 //for enemys without current target, pick a new spot near the player as target
 fn set_target_near_player(
     mut commands: Commands,
-    query: Query<(Entity, &State), (With<Enemy>, Without<Target>)>,
+    enemies_query: Query<(Entity, &State), (With<Enemy>, Without<Target>)>,
     player_query: Query<&Transform, With<Player>>,
 ) {
     let mut rng = rand::thread_rng();
-    let transforms = player_query.iter().collect::<Vec<_>>();
+    let p_transforms = player_query.iter().collect::<Vec<_>>();
 
-    for (entity, state) in query.iter() {
-        if *state == State::Idle {
-            if let Some(player_transform) = transforms.choose(&mut rng) {
+    for (e_entity, e_state) in enemies_query.iter() {
+        if *e_state == State::Idle {
+            if let Some(p_transform) = p_transforms.choose(&mut rng) {
                 let x_offset = rng.gen_range(-100.0..100.);
                 let y_offset = rng.gen_range(-100.0..100.);
-                commands.entity(entity).insert(Target {
+                commands.entity(e_entity).insert(Target {
                     position: Vec2::new(
-                        player_transform.translation.x + x_offset,
-                        (player_transform.translation.y + y_offset)
-                            .clamp(consts::MIN_Y, consts::MAX_Y),
+                        p_transform.translation.x + x_offset,
+                        (p_transform.translation.y + y_offset).clamp(consts::MIN_Y, consts::MAX_Y),
                     ),
                 });
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,23 +328,34 @@ fn game_over_on_players_death(
 //for enemys without current target, pick a new spot near the player as target
 fn set_target_near_player(
     mut commands: Commands,
-    enemies_query: Query<(Entity, &State), (With<Enemy>, Without<Target>)>,
+    mut enemies_query: Query<(Entity, &State, &mut TripPointX), (With<Enemy>, Without<Target>)>,
     player_query: Query<&Transform, With<Player>>,
 ) {
     let mut rng = rand::thread_rng();
     let p_transforms = player_query.iter().collect::<Vec<_>>();
+    let max_player_x = p_transforms
+        .iter()
+        .map(|transform| transform.translation.x)
+        .max_by(f32::total_cmp);
 
-    for (e_entity, e_state) in enemies_query.iter() {
-        if *e_state == State::Idle {
-            if let Some(p_transform) = p_transforms.choose(&mut rng) {
-                let x_offset = rng.gen_range(-100.0..100.);
-                let y_offset = rng.gen_range(-100.0..100.);
-                commands.entity(e_entity).insert(Target {
-                    position: Vec2::new(
-                        p_transform.translation.x + x_offset,
-                        (p_transform.translation.y + y_offset).clamp(consts::MIN_Y, consts::MAX_Y),
-                    ),
-                });
+    if let Some(max_player_x) = max_player_x {
+        for (e_entity, e_state, mut e_trip_point_x) in enemies_query.iter_mut() {
+            if *e_state == State::Idle {
+                if let Some(p_transform) = p_transforms.choose(&mut rng) {
+                    if max_player_x > e_trip_point_x.0 {
+                        e_trip_point_x.0 = f32::MIN;
+
+                        let x_offset = rng.gen_range(-100.0..100.);
+                        let y_offset = rng.gen_range(-100.0..100.);
+                        commands.entity(e_entity).insert(Target {
+                            position: Vec2::new(
+                                p_transform.translation.x + x_offset,
+                                (p_transform.translation.y + y_offset)
+                                    .clamp(consts::MIN_Y, consts::MAX_Y),
+                            ),
+                        });
+                    }
+                }
             }
         }
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -135,7 +135,12 @@ pub struct FighterSpawnMeta {
     pub fighter_handle: Handle<FighterMeta>,
     pub location: Vec3,
     // Set only for enemies.
-    pub trip_point_x: Option<f32>,
+    #[serde(default = "default_f32_min")]
+    pub trip_point_x: f32,
+}
+
+fn default_f32_min() -> f32 {
+    f32::MIN
 }
 
 #[derive(HasLoadProgress, TypeUuid, Deserialize, Clone, Debug)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -134,6 +134,8 @@ pub struct FighterSpawnMeta {
     #[serde(skip)]
     pub fighter_handle: Handle<FighterMeta>,
     pub location: Vec3,
+    // Set only for enemies.
+    pub trip_point_x: Option<f32>,
 }
 
 #[derive(HasLoadProgress, TypeUuid, Deserialize, Clone, Debug)]


### PR DESCRIPTION
Simplest implementation of trip points (replaces enemy FOV).

A trip point is associated to each enemy, which don't set a target unless any player ever trespassed the point. Once a point has been trespassed, the given trip point is set to f32::MIN.

This can be easily changed in the future, for more sophisticated logic (e.g. enemy state change).

Closes #183.