### PR TITLE
Deserialization Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ dependencies = [
  "intl-memoizer",
  "ron",
  "serde",
- "serde_yaml 0.9.2",
+ "serde_yaml",
  "thiserror",
  "tracing",
  "unic-langid",
@@ -2133,12 +2133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2896,7 +2890,7 @@ dependencies = [
  "punchy_macros",
  "rand",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "structopt",
  "sys-locale",
  "thiserror",
@@ -3143,18 +3137,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -4068,13 +4050,4 @@ dependencies = [
  "nix 0.22.3",
  "winapi",
  "winapi-wsapoll",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bevy_kira_audio = { version = "0.11.0", features = ["mp3"] }
 bevy_rapier2d = { version = "0.16.0", features = ["debug-render"] }
 iyes_loopless = "0.7.0"
 serde = { version = "1.0.137", features = ["derive"] }
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.2"
 thiserror = "1.0.31"
 structopt = "0.3.26"
 rand = "0.8.5"

--- a/assets/default.game.yaml
+++ b/assets/default.game.yaml
@@ -21,72 +21,50 @@ default_settings:
     # Gamepad controls
     gamepad:
       movement:
-        up:
-          SingleAxis:
-            axis_type:
-              Gamepad: LeftStickY
-            positive_low: 0.1
-            negative_low: -1.0
-        left:
-          SingleAxis:
-            axis_type:
-              Gamepad: LeftStickX
-            positive_low: 1.0
-            negative_low: -0.1
-        down:
-          SingleAxis:
-            axis_type:
-              Gamepad: LeftStickY
-            positive_low: 1.0
-            negative_low: -0.1
-        right:
-          SingleAxis:
-            axis_type:
-              Gamepad: LeftStickX
-            positive_low: 0.1
-            negative_low: -1.0
-      flop_attack:
-        GamepadButton: South
-      shoot:
-        GamepadButton: East
-      throw:
-        GamepadButton: West
+        up: !SingleAxis
+          axis_type: !Gamepad LeftStickY
+          positive_low: 0.1
+          negative_low: -1.0
+
+        left: !SingleAxis
+          axis_type: !Gamepad LeftStickX
+          positive_low: 1.0
+          negative_low: -0.1
+
+        down: !SingleAxis
+          axis_type: !Gamepad LeftStickY
+          positive_low: 1.0
+          negative_low: -0.1
+
+        right: !SingleAxis
+          axis_type: !Gamepad LeftStickX
+          positive_low: 0.1
+          negative_low: -1.0
+      flop_attack: !GamepadButton South
+      shoot: !GamepadButton East
+      throw: !GamepadButton West
 
     # Controls for the first keyboard player ( left side )
     keyboard1:
       movement:
-        up:
-          Keyboard: W
-        down:
-          Keyboard: S
-        left:
-          Keyboard: A
-        right:
-          Keyboard: D
-      flop_attack:
-        Keyboard: Space
-      shoot:
-        Keyboard: V
-      throw:
-        Keyboard: C
+        up: !Keyboard W
+        down: !Keyboard S
+        left: !Keyboard A
+        right: !Keyboard D
+      flop_attack: !Keyboard Space
+      shoot: !Keyboard V
+      throw: !Keyboard C
 
     # Controls for the second keyboard player ( right side )
     keyboard2:
       movement:
-        up:
-          Keyboard: Up
-        down:
-          Keyboard: Down
-        left:
-          Keyboard: Left
-        right:
-          Keyboard: Right
-      flop_attack:
-        Keyboard: Comma
-      shoot:
-        Keyboard: RShift
-      throw:
-        Keyboard: Period
+        up: !Keyboard Up
+        down: !Keyboard Down
+        left: !Keyboard Left
+        right: !Keyboard Right
+      flop_attack: !Keyboard Comma
+      shoot: !Keyboard RShift
+      throw: !Keyboard Period
 
 ui_theme:
   font_families:

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -8,6 +8,7 @@ use bevy::{
     utils::HashMap,
 };
 use iyes_loopless::condition::ConditionSet;
+use serde::{de::SeqAccess, Deserializer};
 
 pub struct AnimationPlugin;
 
@@ -45,9 +46,51 @@ impl Facing {
 #[derive(serde::Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Clip {
+    #[serde(deserialize_with = "deserialize_range_from_array")]
     pub frames: Range<usize>,
     #[serde(default)]
     pub repeat: bool,
+}
+
+fn deserialize_range_from_array<'de, D>(de: D) -> Result<Range<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    de.deserialize_tuple(2, RangeVisitor)
+}
+
+struct RangeVisitor;
+
+impl<'de> serde::de::Visitor<'de> for RangeVisitor {
+    type Value = Range<usize>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("A sequence of 2 integers")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let start: usize = if let Some(start) = seq.next_element()? {
+            start
+        } else {
+            return Err(serde::de::Error::invalid_length(
+                0,
+                &"a sequence with a length of 2",
+            ));
+        };
+        let end: usize = if let Some(end) = seq.next_element()? {
+            end
+        } else {
+            return Err(serde::de::Error::invalid_length(
+                1,
+                &"a sequence with a length of 2",
+            ));
+        };
+
+        Ok(start..end)
+    }
 }
 
 #[derive(Component)]


### PR DESCRIPTION
Un reverts https://github.com/fishfight/punchy/commit/a60ed4a4864f1c7ff8f5a0633840c94cd9676876 and adds a more graceful fallback to deserialization problems.

The fallback right now is to log an error when we fail to deserialize something, but we just act like the data isn't there afterwards. This means that subsequent attempts to save will overwrite the non-understood value.

This way we get some notification that something unexpected happened, but we don't panic and we can gracefully continue without having to manually modify files on the filesystem or browser storage.